### PR TITLE
Fix section name for blog layout

### DIFF
--- a/site/_core/BlogLayout.js
+++ b/site/_core/BlogLayout.js
@@ -17,7 +17,7 @@ var BlogLayout = React.createClass({
     var page = this.props.page;
     var site = this.props.site;
     return (
-      <Site section="docs">
+      <Site section="blog">
         <section className="content wrap documentationContent">
           <BlogSidebar site={site} page={page} />
           <div className="inner-content">


### PR DESCRIPTION
Ensure that when navigating blog articles, blog header link has the active class rather than docs.