### PR TITLE
Fix document.title

### DIFF
--- a/site/_core/BlogLayout.js
+++ b/site/_core/BlogLayout.js
@@ -17,7 +17,7 @@ var BlogLayout = React.createClass({
     var page = this.props.page;
     var site = this.props.site;
     return (
-      <Site section="blog">
+      <Site section="blog" title={page.title}>
         <section className="content wrap documentationContent">
           <BlogSidebar site={site} page={page} />
           <div className="inner-content">

--- a/site/_core/DocsLayout.js
+++ b/site/_core/DocsLayout.js
@@ -17,7 +17,7 @@ var DocsLayout = React.createClass({
     var page = this.props.page;
     var site = this.props.site;
     return (
-      <Site section="docs">
+      <Site section="docs" title={page.title}>
         <section className="content wrap documentationContent">
           <DocsSidebar site={site} page={page} />
           <div className="inner-content">

--- a/site/_core/Site.js
+++ b/site/_core/Site.js
@@ -12,12 +12,13 @@ var SiteData = require('./SiteData');
 
 var Site = React.createClass({
   render: function() {
+    var pageTitle = this.props.title ? `${this.props.title} | GraphQL` : `GraphQL | ${SiteData.description}`;
     return (
       <html>
         <head>
           <meta charSet="utf-8" />
           <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-          <title>GraphQL | {SiteData.description}</title>
+          <title>{pageTitle}</title>
           <meta name="viewport" content="width=device-width" />
           <meta property="og:title" content={'GraphQL | ' + SiteData.description} />
           <meta property="og:type" content="website" />


### PR DESCRIPTION
Currently, all `document.title` are 'GraphQL | A data query language and runtime'.
It is a bit confusing.

This PR is for fixing it.
The default title is same before.
If a Markdown has 'title', a generated site uses this as the document.title.

e.g.
- http://graphql.org/docs/getting-started/
  - before - `GraphQL | A data query language and runtime`
  - after - `Getting Started  | GraphQL`
- http://graphql.org/blog/subscriptions-in-graphql-and-relay/
  - before - `GraphQL | A data query language and runtime`
  - after - `Subscriptions in GraphQL and Relay | GraphQL`
