### PR TITLE
Add missing `description` field on `GraphQLArgumentConfig` type

### DIFF
--- a/site/docs/APIReference-TypeSystem.md
+++ b/site/docs/APIReference-TypeSystem.md
@@ -282,6 +282,7 @@ type GraphQLFieldConfigArgumentMap = {
 type GraphQLArgumentConfig = {
   type: GraphQLInputType;
   defaultValue?: any;
+  description?: ?string;
 }
 
 type GraphQLFieldConfigMap = {


### PR DESCRIPTION
See https://github.com/graphql/graphql-js/blob/60e55da31f761303f60bc8258a71d278939e52c0/src/type/definition.js#L491