### PR TITLE
Fixed *-test.js links

### DIFF
--- a/site/docs/Walkthrough-Introspection.md
+++ b/site/docs/Walkthrough-Introspection.md
@@ -11,7 +11,7 @@ queries it supports. GraphQL allows us to do so using the introspection
 system!
 
 For our Star Wars example, the file
-[starWarsIntrospectionTests.js](https://github.com/graphql/graphql-js/blob/master/src/__tests__/starWarsIntrospectionTests.js)
+[starWarsIntrospection-test.js](https://github.com/graphql/graphql-js/blob/master/src/__tests__/starWarsIntrospection-test.js)
 contains a number of queries demonstrating the introspection system, and is a
 test file that can be run to exercise the reference implementation's
 introspection system.

--- a/site/docs/Walkthrough-Queries.md
+++ b/site/docs/Walkthrough-Queries.md
@@ -10,7 +10,7 @@ GraphQL queries declaratively describe what data the issuer wishes
 to fetch from whoever is fulfilling the GraphQL query.
 
 For our Star Wars example, the
-[starWarsQueryTests.js](https://github.com/graphql/graphql-js/blob/master/src/__tests__/starWarsQueryTests.js)
+[starWarsQuery-test.js](https://github.com/graphql/graphql-js/blob/master/src/__tests__/starWarsQuery-test.js)
 file in the GraphQL.js repository contains a number of queries and responses.
 That file is a test file that uses the schema discussed in the "Type System" walkthrough and a set of
 sample data, located in

--- a/site/docs/Walkthrough-Validation.md
+++ b/site/docs/Walkthrough-Validation.md
@@ -12,7 +12,7 @@ developers when an invalid query has been created, without having to rely
 on runtime checks.
 
 For our Star Wars example, the file
-[starWarsValidationTests.js](https://github.com/graphql/graphql-js/blob/master/src/__tests__/starWarsValidationTests.js)
+[starWarsValidation-test.js](https://github.com/graphql/graphql-js/blob/master/src/__tests__/starWarsValidation-test.js)
 contains a number of queries demonstrating various invalidities, and is a test
 file that can be run to exercise the reference implementation's validator.
 


### PR DESCRIPTION
I've fixed the `*-test.js` 404 errors in docs, matching the rename in https://github.com/graphql/graphql-js/commit/39744381d5173795d3b245dcb5d86e78bb3638fe