### PR TITLE
Update resolve function signature to 0.5.0

### DIFF
--- a/site/docs/APIReference-TypeSystem.md
+++ b/site/docs/APIReference-TypeSystem.md
@@ -262,6 +262,7 @@ type GraphQLFieldConfigMapThunk = () => GraphQLFieldConfigMap;
 type GraphQLFieldResolveFn = (
   source?: any,
   args?: {[argName: string]: any},
+  context?: any,
   info?: GraphQLResolveInfo
 ) => any
 


### PR DESCRIPTION
Adds the context to the ResolveFn definition, fixing a long-standing issue with out-of date docs.