### PR TITLE
Make RSS valid

### DIFF
--- a/resources/renderReactPage.js
+++ b/resources/renderReactPage.js
@@ -24,6 +24,9 @@ function renderReactPage(options) {
   var html = React.renderToStaticMarkup(React.createElement(component, props));
 
   if (html.indexOf('<feed') !== -1) {
+    // react remove namespace so we re-add manually
+    html = html.replace('<feed>', '<feed xmlns="http://www.w3.org/2005/Atom">');
+
     return '<?xml version="1.0" encoding="utf-8"?>' + html;
   }
 

--- a/site/blog/rss.xml.js
+++ b/site/blog/rss.xml.js
@@ -16,15 +16,17 @@ var BlogRss = React.createClass({
       .filter(file => !file.draft && path.extname(file.relPath) === '.md')
       .sort((a, b) => a.date < b.date);
     return (
-      <feed xmlns="http://www.w3.org/2005/Atom">
+      <feed>
         <title>Blog | GraphQL</title>
         <link href="http://graphql.org/blog/"/>
+        <id>http://graphql.org/blog/</id>
+        <updated>{new Date(posts[0].date).toISOString()}</updated>
 
         {posts.map(post =>
           <entry>
             <title>{post.title}</title>
             <link href={'http://graphql.org' + post.url}/>
-            <id>{post.permalink}</id>
+            <id>http://graphql.org{post.url}</id>
             <updated>{new Date(post.date).toISOString()}</updated>
             <summary>{post.title}</summary>
             <content>{post.title}</content>


### PR DESCRIPTION
Validation failed with the previous feed (even if I checked it ..)
http://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fgraphql.org%2Fblog%2Frss.xml

Following #40 

```
This feed does not validate.
    line 1, column 38: Missing namespace for feed [help]
    <?xml version="1.0" encoding="utf-8"?><feed><title>Blog | GraphQL</title><li ...
                                          ^
    line 1, column 112: Missing feed element: id [help]
    ... ><link href="http://graphql.org/blog/"/><entry><title>Wrapping a REST AP ...
                                                 ^
    line 1, column 112: Missing feed element: updated [help]
    ... ><link href="http://graphql.org/blog/"/><entry><title>Wrapping a REST AP ...
                                                 ^
    line 1, column 263: id must be a full and valid URL: /blog/rest-api-graphql-wrapper/ (4 occurrences) [help]
    ... r/"/><id>/blog/rest-api-graphql-wrapper/</id><updated>2016-05-05T00:00:0 ...
```