### PR TITLE
expand out api ref sidebar

### DIFF
--- a/site/_core/DocsSidebar.js
+++ b/site/_core/DocsSidebar.js
@@ -8,26 +8,58 @@
 
 var React = require('react');
 
+// thisPageID is the id of the rendering page
+// category is the category object to render a sidebar for
+function sidebarForCategory(thisPageID, category) {
+  var listItems = [];
+  for (var page of category.links) {
+    var target = page.url.match(/^https?:/) && '_blank';
+    var marginLeft = page.indent ? 20 : 0;
+
+    // Link for the main page overall
+    listItems.push(
+      <li key={page.permalink}>
+        <a
+          target={target}
+          style={{marginLeft: marginLeft}}
+          className={page.id === thisPageID ? 'active' : ''}
+          href={page.url}>
+          {page.sidebarTitle || page.title}
+        </a>
+      </li>
+    );
+
+    // Sublinks to any page sub-parts
+    if (page.sublinks) {
+      var sublinks = page.sublinks.split(',').sort();
+      for (var sublink of sublinks) {
+        listItems.push(
+          <li key={page.permalink + '-' + sublink}>
+            <a
+              target={target}
+              style={{marginLeft: marginLeft + 20}}
+              href={page.url + '#' + sublink.toLowerCase()}>
+              {sublink}
+            </a>
+          </li>
+        );
+      }
+    }
+  }
+
+  return (
+    <div className="nav-docs-section" key={category.name}>
+      <h3>{category.name}</h3>
+      <ul>{listItems}</ul>
+    </div>
+  );
+}
+
 var DocsSidebar = React.createClass({
   render: function() {
     return <div className="nav-docs">
       {getCategories(this.props.site, this.props.firstURL).map((category) =>
-        <div className="nav-docs-section" key={category.name}>
-          <h3>{category.name}</h3>
-          <ul>
-            {category.links.map(page =>
-              <li key={page.permalink}>
-                <a
-                  target={page.url.match(/^https?:/) && '_blank'}
-                  style={{marginLeft: page.indent ? 20 : 0}}
-                  className={page.id === this.props.page.id ? 'active' : ''}
-                  href={page.url}>
-                  {page.sidebarTitle || page.title}
-                </a>
-              </li>
-            )}
-          </ul>
-        </div>
+        sidebarForCategory(this.props.page.id, category)
       )}
     </div>;
   }

--- a/site/docs/APIReference-Errors.md
+++ b/site/docs/APIReference-Errors.md
@@ -1,9 +1,10 @@
 ---
-title: Errors
+title: graphql/error
 layout: ../_core/CodeLayout
 category: API Reference
 permalink: /docs/api-reference-errors/
-next: /docs/api-reference-utilities/
+sublinks: GraphQLError,syntaxError,locatedError,formatError
+next: /docs/api-reference-execution/
 ---
 
 The `graphql/error` module is responsible for creating and formating

--- a/site/docs/APIReference-Execution.md
+++ b/site/docs/APIReference-Execution.md
@@ -1,9 +1,10 @@
 ---
-title: Execution
+title: graphql/execution
 layout: ../_core/CodeLayout
 category: API Reference
 permalink: /docs/api-reference-execution/
-next: /docs/api-reference-errors/
+sublinks: execute
+next: /docs/api-reference-language/
 ---
 
 The `graphql/execution` module is responsible for the execution phase of

--- a/site/docs/APIReference-GraphQL.md
+++ b/site/docs/APIReference-GraphQL.md
@@ -1,9 +1,10 @@
 ---
-title: GraphQL
+title: graphql
 layout: ../_core/CodeLayout
 category: API Reference
 permalink: /docs/api-reference-graphql/
-next: /docs/api-reference-language/
+sublinks: graphql
+next: /docs/api-reference-errors/
 ---
 
 The `graphql` module exports a core subset of GraphQL functionality for creation

--- a/site/docs/APIReference-Language.md
+++ b/site/docs/APIReference-Language.md
@@ -1,8 +1,9 @@
 ---
-title: Language
+title: graphql/language
 layout: ../_core/CodeLayout
 category: API Reference
 permalink: /docs/api-reference-language/
+sublinks: Source,getLocation,lex,parse,parseValue,Kind,visit,BREAK,print
 next: /docs/api-reference-type-system/
 ---
 

--- a/site/docs/APIReference-TypeSystem.md
+++ b/site/docs/APIReference-TypeSystem.md
@@ -1,9 +1,10 @@
 ---
-title: Type System
+title: graphql/types
 layout: ../_core/CodeLayout
 category: API Reference
 permalink: /docs/api-reference-type-system/
-next: /docs/api-reference-validation/
+sublinks: GraphQLSchema,GraphQLScalarType,GraphQLObjectType,GraphQLInterfaceType,GraphQLUnionType,GraphQLEnumType,GraphQLInputObjectType,GraphQLList,GraphQLNonNull,isInputType,isOutputType,isLeafType,isCompositeType,isAbstractType,getNullableType,getNamedType,GraphQLInt,GraphQLFloat,GraphQLString,GraphQLBoolean,GraphQLID
+next: /docs/api-reference-utilities/
 ---
 
 The `graphql/type` module is responsible for defining GraphQL types and schema.
@@ -80,11 +81,6 @@ var GraphQLType = require('graphql/type'); // CommonJS
 </ul>
 
 *Predicates*
-
-These types may be used as output types as the result of fields
-These types may describe types which may be leaf values
-These types may describe the parent context of a selection set
-These types may describe a combination of object types
 
 <ul class="apiIndex">
   <li>

--- a/site/docs/APIReference-Utilities.md
+++ b/site/docs/APIReference-Utilities.md
@@ -1,8 +1,10 @@
 ---
-title: Utilities
+title: graphql/utilities
 layout: ../_core/CodeLayout
 category: API Reference
 permalink: /docs/api-reference-utilities/
+sublinks: introspectionQuery,buildClientSchema,printSchema,printIntrospectionSchema,buildASTSchema,typeFromAST,astFromValue,TypeInfo,isValidJSValue,isValidLiteralValue
+next: /docs/api-reference-validation/
 ---
 
 The `graphql/utilities` module contains common useful computations to use with

--- a/site/docs/APIReference-Validation.md
+++ b/site/docs/APIReference-Validation.md
@@ -1,9 +1,9 @@
 ---
-title: Validation
+title: graphql/validation
 layout: ../_core/CodeLayout
 category: API Reference
 permalink: /docs/api-reference-validation/
-next: /docs/api-reference-execution/
+sublinks: validate,specifiedRules
 ---
 
 The `graphql/validation` module fulfills the Validation phase of fulfilling a


### PR DESCRIPTION
Add "sublinks" to the sidebar, so that for each npm module, the docs can also deeply link to each exported thing. Now it looks like:

<img width="156" alt="screen shot 2016-09-09 at 4 27 13 pm" src="https://cloud.githubusercontent.com/assets/106475/18405815/4e9fbd46-76aa-11e6-9c46-88ca76d6c7dc.png">
