### PR TITLE
Typo in args reference

### DIFF
--- a/site/graphql-js/Guides-ConstructingTypes.md
+++ b/site/graphql-js/Guides-ConstructingTypes.md
@@ -95,7 +95,7 @@ var queryType = new graphql.GraphQLObjectType({
         id: { type: graphql.GraphQLString }
       },
       resolve: function (_, {id}) {
-        return fakeDatabase[args.id];
+        return fakeDatabase[id];
       }
     }
   }


### PR DESCRIPTION
Looks like `args` was modified to use destructuring, but the reference to `args.id` wasn't updated accordingly