### PR TITLE
Fixes 404 on docsearch for GraphQL/Errors

### DIFF
--- a/site/docs/api-reference-errors/index.html.js
+++ b/site/docs/api-reference-errors/index.html.js
@@ -1,3 +1,3 @@
 var React = require('react')
 var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/graphql-js/errors/" />
+export default () => <Redirect to="/graphql-js/error/" />


### PR DESCRIPTION
DocSearch Results is throwing a 404 for graphql/error redirection.  This should square that up.