### PR TITLE
Removing unnecessary word

### DIFF
--- a/site/learn/Learn-Schema.md
+++ b/site/learn/Learn-Schema.md
@@ -68,7 +68,7 @@ type Starship {
 }
 ```
 
-All arguments are named. Unlike languages like JavaScript and Python where functions take a list of ordered arguments, all arguments in GraphQL are be passed by name specifically. In this case, the `length` field has one defined argument, `unit`.
+All arguments are named. Unlike languages like JavaScript and Python where functions take a list of ordered arguments, all arguments in GraphQL are passed by name specifically. In this case, the `length` field has one defined argument, `unit`.
 
 Arguments can be either required or optional. When an argument is optional, we can define a _default value_ - if the `unit` argument is not passed, it will be set to `METER` by default.
 


### PR DESCRIPTION
This is a super-tiny update:
`all arguments in GraphQL are be passed by name specifically` -> `all arguments in GraphQL are passed by name specifically`