### PR TITLE
fix Introspection link

### DIFF
--- a/site/learn/Learn-Queries.md
+++ b/site/learn/Learn-Queries.md
@@ -283,5 +283,5 @@ Given that there are some situations where you don't know what type you'll get b
 
 In the above query, `search` returns a union type that can be one of three options. It would be impossible to tell apart the different types from the client without the `__typename` field.
 
-GraphQL services provide a few meta fields, the rest of which are used to expose the [Introspection](./introspection/) system.
+GraphQL services provide a few meta fields, the rest of which are used to expose the [Introspection](../introspection/) system.
 


### PR DESCRIPTION
Background:
- the current introspection link seems to be broken... pointing to `http://graphql.org/learn/queries/introspection/` 

Info
- this pr points to `http://graphql.org/learn/introspection/` instead
