### PR TITLE
Update Tutorial-PassingArguments.md

### DIFF
--- a/site/graphql-js/Tutorial-PassingArguments.md
+++ b/site/graphql-js/Tutorial-PassingArguments.md
@@ -27,10 +27,10 @@ The exclamation point in `Int!` indicates that `numDice` can't be null, which me
 So far, our resolver functions took no arguments. When a resolver takes arguments, they are passed as one “args” object, as the first argument to the function. So rollDice could be implemented as:
 
 ```javascript
-var root = {
+const root = {
   rollDice: function (args) {
-    var output = [];
-    for (var i = 0; i < args.numDice; i++) {
+    let output = [];
+    for (let i = 0; i < args.numDice; i++) {
       output.push(1 + Math.floor(Math.random() * (args.numSides || 6)));
     }
     return output;
@@ -41,10 +41,10 @@ var root = {
 It's convenient to use [ES6 destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) for these parameters, since you know what format they will be. So we can also write `rollDice` as
 
 ```javascript
-var root = {
+const root = {
   rollDice: function ({numDice, numSides}) {
-    var output = [];
-    for (var i = 0; i < numDice; i++) {
+    let output = [];
+    for (let i = 0; i < numDice; i++) {
       output.push(1 + Math.floor(Math.random() * (numSides || 6)));
     }
     return output;
@@ -57,29 +57,29 @@ If you're familiar with destructuring, this is a bit nicer because the line of c
 The entire code for a server that hosts this `rollDice` API is:
 
 ```javascript
-var express = require('express');
-var graphqlHTTP = require('express-graphql');
-var { buildSchema } = require('graphql');
+const express = require('express');
+const graphqlHTTP = require('express-graphql');
+const { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language
-var schema = buildSchema(`
+const schema = buildSchema(`
   type Query {
     rollDice(numDice: Int!, numSides: Int): [Int]
   }
 `);
 
 // The root provides a resolver function for each API endpoint
-var root = {
+const root = {
   rollDice: function ({numDice, numSides}) {
-    var output = [];
-    for (var i = 0; i < numDice; i++) {
+    let output = [];
+    for (let i = 0; i < numDice; i++) {
       output.push(1 + Math.floor(Math.random() * (numSides || 6)));
     }
     return output;
   }
 };
 
-var app = express();
+const app = express();
 app.use('/graphql', graphqlHTTP({
   schema: schema,
   rootValue: root,
@@ -104,9 +104,9 @@ When you're passing arguments in code, it's generally better to avoid constructi
 For example, some JavaScript code that calls our server above is:
 
 ```javascript
-var dice = 3;
-var sides = 6;
-var xhr = new XMLHttpRequest();
+const dice = 3;
+const sides = 6;
+const xhr = new XMLHttpRequest();
 xhr.responseType = 'json';
 xhr.open("POST", "/graphql");
 xhr.setRequestHeader("Content-Type", "application/json");
@@ -114,7 +114,7 @@ xhr.setRequestHeader("Accept", "application/json");
 xhr.onload = function () {
   console.log('data returned:', xhr.response);
 }
-var query = `query RollDice($dice: Int!, $sides: Int) {
+const query = `query RollDice($dice: Int!, $sides: Int) {
   rollDice(numDice: $dice, numSides: $sides)
 }`;
 xhr.send(JSON.stringify({


### PR DESCRIPTION
Use ES6 let and const instead of var.  This is best practice and propose that GraphQL docs move in this direction.

If you agree, happy to review remainder of doc and make similar edits.