### PR TITLE
Fix underscores being parsed in introspection doc

### DIFF
--- a/site/learn/Learn-Introspection.md
+++ b/site/learn/Learn-Introspection.md
@@ -45,9 +45,9 @@ Wow, that's a lot of types! What are they? Let's group them:
 defined in our type system.
  - **String, Boolean** - These are built-in scalars that the type system
 provided.
- - **__Schema, __Type, __TypeKind, __Field, __InputValue, __EnumValue,
-__Directive** - These all are preceded with a double underscore, indicating
-that they are part of the introspection system.
+ - **\_\_Schema, \_\_Type, \_\_TypeKind, \_\_Field, \_\_InputValue,
+\_\_EnumValue, \_\_Directive** - These all are preceded with a double
+underscore, indicating that they are part of the introspection system.
 
 Now, let's try and figure out a good place to start exploring what queries are
 available. When we designed our type system, we specified what type all queries


### PR DESCRIPTION
Escaping underscores using backslashes to avoid Markdown treating them
as bold and missing the last one.

### Results (via Atom editor though)

Before | After
--- | ---
<img width="631" alt="screen shot 2016-10-03 at 20 17 44" src="https://cloud.githubusercontent.com/assets/113730/19058758/f573e326-89a7-11e6-9777-b68ec310a0d5.png"> | <img width="620" alt="screen shot 2016-10-03 at 20 18 08" src="https://cloud.githubusercontent.com/assets/113730/19058759/f58437d0-89a7-11e6-87d6-685a64397cc7.png">
