### PR TITLE
Correct `ofType` name for`id` to be `ID`

### DIFF
--- a/site/learn/Learn-Introspection.md
+++ b/site/learn/Learn-Introspection.md
@@ -136,8 +136,8 @@ Those are our fields that we defined on `Droid`!
 
 `id` looks a bit weird there, it has no name for the type. That's
 because it's a "wrapper" type of kind `NON_NULL`. If we queried for
-`ofType` on that field's type, we would find the `String` type there,
-telling us that this is a non-null String.
+`ofType` on that field's type, we would find the `ID` type there,
+telling us that this is a non-null ID.
 
 Similarly, both `friends` and `appearsIn` have no name, since they are the
 `LIST` wrapper type. We can query for `ofType` on those types, which will


### PR DESCRIPTION
I'm not sure I understand, but in the example after this they do include`ofType` and end up with this:

``` json
{
          "name": "id",
          "type": {
            "name": null,
            "kind": "NON_NULL",
            "ofType": {
              "name": "ID",
              "kind": "SCALAR"
            }
          }
        },
```

Note that not the name nor the kind is`String`.
