### PR TITLE
Fix missing argument error in graphene example

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -185,7 +185,7 @@ import graphene
 class Query(graphene.ObjectType):
   hello = graphene.String()
 
-  def resolve_hello(self, args, info):
+  def resolve_hello(self, args, context, info):
     return 'Hello world!'
 
 schema = graphene.Schema(query=Query)


### PR DESCRIPTION
pip3 install graphene
python3 hello.py

```
An error occurred while resolving field Query.hello
Traceback (most recent call last):
  File "/home/alpha/.pyenv/versions/3.5.1/lib/python3.5/site-packages/graphql/execution/executor.py", line 190, in resolve_or_error
    return executor.execute(resolve_fn, source, args, context, info)
  File "/home/alpha/.pyenv/versions/3.5.1/lib/python3.5/site-packages/graphql/execution/executors/sync.py", line 7, in execute
    return fn(*args, **kwargs)
TypeError: resolve_hello() takes 3 positional arguments but 4 were given
None
```

Also see: https://github.com/graphql-python/graphene/#examples