### PR TITLE
Adjust homepage media queries to works correctly on mobile

### DIFF
--- a/site/_core/Site.js
+++ b/site/_core/Site.js
@@ -21,7 +21,7 @@ export default ({ page, category, title, section, className, noSearch, children 
           `${title} | ${category || 'GraphQL'}` :
           `GraphQL | ${SiteData.description}`}
       </title>
-      <meta name="viewport" content="width=640" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
       <meta property="og:title" content="GraphQL: A query language for APIs." />
       <meta property="og:description" content="GraphQL provides a complete description of the data in your API, gives clients the power to ask for exactly what they need and nothing more, makes it easier to evolve APIs over time, and enables powerful developer tools." />
       <meta property="og:type" content="website" />
@@ -80,7 +80,7 @@ export default ({ page, category, title, section, className, noSearch, children 
             <a href="https://twitter.com/GraphQL" target="_blank" rel="noopener noreferrer">Twitter</a>
           </div>
           <div>
-            <h5>More</h5>
+            <h5><a href="#">More</a></h5>
             <a href="/blog">GraphQL Team Blog</a>
             <a href="http://facebook.github.io/graphql/" target="_blank" rel="noopener noreferrer">Read the Spec</a>
             <a href="https://github.com/graphql" target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/site/_css/graphql.less
+++ b/site/_css/graphql.less
@@ -123,6 +123,11 @@ header {
   background: white;
   box-shadow: inset 0 -1px 0 0px rgba(0, 0, 0, 0.1);
   z-index: 10;
+  @media screen and (max-width: 480px) {
+    margin-bottom: 20px;
+    height: auto;
+    padding-top: 20px;
+  }
 
   // Home link within nav.
   .nav-home {
@@ -133,12 +138,23 @@ header {
     display: inline-block;
     padding-right: 1em;
     text-decoration: none;
+    @media screen and (max-width: 480px) {
+      text-align: center;
+      font-size: 13px;
+    }
 
     img {
       vertical-align: -9px;
       margin-right: 6px;
       width: 30px;
       height: 30px;
+    }
+  }
+
+  section {
+    @media screen and (max-width: 480px) {
+      display: flex;
+      flex-direction: column;
     }
   }
 }
@@ -158,6 +174,9 @@ nav {
     line-height: 50px;
     padding: 0 1em;
     transition: color 0.1s ease-out;
+    @media screen and (max-width: 480px) {
+      font-size: 13px;
+    }
 
     &:hover, &:focus, &.active {
       color: @text-color;
@@ -184,10 +203,16 @@ footer {
   .sitemap {
     display: flex;
     justify-content: space-between;
+    flex-wrap: wrap;
     margin-bottom: 3em;
 
     div {
       flex: 1;
+      @media screen and (max-width: 480px) {
+        flex: 1 1 50%;
+        margin-bottom: 20px;
+        text-align: center;
+      }
     }
 
     .nav-home {
@@ -210,11 +235,13 @@ footer {
     a {
       color: white;
       display: table;
-      margin: 2px -10px;
       padding: 3px 10px;
       &:hover, &:focus {
         color: @rhodamine-color;
         text-decoration: none;
+      }
+      @media screen and (max-width: 480px) {
+        width: 100%;
       }
     }
 
@@ -223,10 +250,6 @@ footer {
 
       &, & > a {
         color: lighten(@dark-color, 50%);
-      }
-
-      & > a {
-        margin: 0 -10px;
       }
     }
   }

--- a/site/_css/index.less
+++ b/site/_css/index.less
@@ -94,6 +94,9 @@ body.index {
         margin-top: -3%;
         flex-direction: row;
       }
+      @media screen and (max-width: 480px) {
+        padding: 0;
+      }
     }
 
     .named-logo {
@@ -101,6 +104,9 @@ body.index {
       animation: fade 1.2s ease-in-out;
       animation-fill-mode: both;
       margin-right: 18px;
+      @media screen and (max-width: 480px) {
+        margin: 20px 0;
+      }
 
       h1 {
         color: @rhodamine-color;
@@ -129,6 +135,9 @@ body.index {
       @media screen and (max-width: 1019px) {
         text-align: center;
       }
+      @media screen and (max-width: 480px) {
+        margin: 20px 0;
+      }
 
       h3 {
         color: white;
@@ -143,6 +152,9 @@ body.index {
         color: white;
         @media screen and (max-width: 1019px) {
           display: inline-block;
+        }
+        @media screen and (max-width: 480px) {
+          width: 100%;
         }
       }
 
@@ -216,6 +228,10 @@ body.index {
     text-align: center;
     max-width: 760px;
     padding-top: 6em;
+    @media screen and (max-width: 480px) {
+      .body-font(18px);
+      padding-top: 2em;
+    }
   }
 
   .grayWash {
@@ -292,6 +308,9 @@ body.index {
       display: flex;
       flex-direction: column;
       pointer-events: none;
+      @media screen and (max-width: 480px) {
+         width: 100%;
+      }
 
       .query, .response {
         flex: 1;
@@ -340,6 +359,9 @@ body.index {
       height: 500px;
       position: relative;
       pointer-events: none;
+      @media screen and (max-width: 480px) {
+        width: 100%;
+      }
 
       margin: -35px -10px;
       @media screen and (max-width: 1019px) {
@@ -350,6 +372,9 @@ body.index {
         position: absolute;
         left: 0;
         right: 0;
+        @media screen and (max-width: 480px) {
+          width: 100%;
+        }
       }
 
       .phone {
@@ -367,6 +392,9 @@ body.index {
       .query {
         animation: query-up 6s 0s infinite ease-in both;
         left: 175px;
+        @media screen and (max-width: 480px) {
+          left: 120px;
+        }
 
         @keyframes query-up {
           from {
@@ -392,6 +420,9 @@ body.index {
       .response {
         animation: response-down 6s 2.3s infinite ease-in both;
         left: 135px;
+        @media screen and (max-width: 480px) {
+          left: 70px;
+        }
 
         @keyframes response-down {
           0% {
@@ -430,6 +461,9 @@ body.index {
       width: 480px;
       display: flex;
       pointer-events: none;
+      @media screen and (max-width: 480px) {
+        width: 100%;
+      }
 
       .type-system, .query {
         background: white;
@@ -519,6 +553,9 @@ body.index {
       width: 2 * @pane-width - 1;
       pointer-events: none;
       overflow-x: hidden;
+      @media screen and (max-width: 480px) {
+        width: 100%;
+      }
 
       .add {
         .code-font(@color: darken(#eaffea, 75%));
@@ -685,6 +722,9 @@ body.index {
       @pane-width: 520px;
       width: @pane-width;
       overflow-y: hidden;
+      @media screen and (max-width: 480px) {
+        width: 100%;
+      }
 
       #leverageCodeView {
         display: flex;
@@ -762,6 +802,9 @@ body.index {
           height: 150px;
           padding: 20px;
         }
+        @media screen and (max-width: 480px) {
+          height: 75px;
+        }
 
         &.round {
           height: 106px;
@@ -769,6 +812,9 @@ body.index {
           @media screen and (min-width: 1020px) {
             height: 158px;
             padding: 16px;
+          }
+          @media screen and (max-width: 480px) {
+            height: 75px;
           }
         }
       }


### PR DESCRIPTION
I wanted to continue reading the documentation on the go and noticed that the homepage wasn't as mobile friendly as it could have been. There was an issue making that made the homepage scroll horizontally and the text was really small. I took a little time to fix it and propose the updated styles.

There is a remaining issue with the _Evolve your API without versions_ example section. I wanted to know if I wasn't wasting my time before trying to fix it :) The issue was already present. If this PR is something you might want to merge, I'll fix it before you do.

Anyhow, let me know what you think of it.

You can see the [Before](http://garno-screenshots.s3.amazonaws.com/graphql-docs-mobile-before.png) & [After](http://garno-screenshots.s3.amazonaws.com/graphql-docs-mobile-after.png) here from Chrome on desktop.