### PR TITLE
Add GraphQL project that is in active development

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -290,6 +290,7 @@ Code that executes a hello world GraphQL query with \`graphql-clj\`:
 
   - [graphql-go](https://github.com/graphql-go/graphql): An implementation of GraphQL for Go / Golang.
   - [graphql-relay-go](https://github.com/graphql-go/relay): A Go/Golang library to help construct a graphql-go server supporting react-relay.
+  - [neelance/graphql-go](https://github.com/neelance/graphql-go): An active implementation of GraphQL in Golang.
 
 ### PHP
 


### PR DESCRIPTION
Given that github.com/graphql-go/graphql stopped developing their implementation this one is a really active project with clearly goals to achieve.