### PR TITLE
Update GraphQLUnionType types

### DIFF
--- a/site/graphql-js/APIReference-TypeSystem.md
+++ b/site/graphql-js/APIReference-TypeSystem.md
@@ -370,10 +370,12 @@ class GraphQLUnionType {
 
 type GraphQLUnionTypeConfig = {
   name: string,
-  types: Array<GraphQLObjectType>,
+  types: GraphQLObjectsThunk | Array<GraphQLObjectType>,
   resolveType?: (value: any, info?: GraphQLResolveInfo) => ?GraphQLObjectType;
   description?: ?string;
 };
+
+type GraphQLObjectsThunk = () => Array<GraphQLObjectType>;
 ```
 
 When a field can return one of a heterogeneous set of types, a Union type


### PR DESCRIPTION
GraphQLUnionType documentation was missing a Thunk definition for 'types'.