### PR TITLE
Fix mobile presentation for "Evolve your API without versions" 

### DIFF
--- a/site/_css/index.less
+++ b/site/_css/index.less
@@ -552,9 +552,9 @@ body.index {
         transition: opacity 0.5s ease-in-out;
         position: absolute;
         left: -1px;
-        right: 0;
         height: 18px;
         padding-left: 2px;
+        padding-right: 97%;
       }
 
       #typeEvolveView {


### PR DESCRIPTION
Hi there @leebyron 👋 

I'm pinging you because the changes proposed here modify a line in [`site/_css/index.less`](https://github.com/graphql/graphql.github.io/blame/source/site/_css/index.less#L555), which was last worked on in https://github.com/graphql/graphql.github.io/commit/79e3bb109b648aa519800f4e74bd59128f1ecd62 as a part of the work done in https://github.com/graphql/graphql.github.io/pull/76.

If you're not maintaining this part of the code anymore, please let me know if there's a better person I should get in touch with about this change. Thanks! 🙇 

### Context

Let's say I navigate to http://graphql.org, where my window has width of less than `1020px`.

Here's how the `Evolve your API without versions` section looks like when viewed from a window whose width is less than `1020px`:

![broken-diff](https://cloud.githubusercontent.com/assets/15894826/21079574/ead600cc-bfd8-11e6-9ba3-1a143dd3b764.png)

This pull request modifies  [`site/_css/index.less`](https://github.com/graphql/graphql.github.io/blob/source/site/_css/index.less) to use the `padding-right` attribute instead of the `right` attribute so it doesn't look like that anymore:

![proposed-changes](https://cloud.githubusercontent.com/assets/15894826/21079547/6686e4b2-bfd8-11e6-8a55-a2fe311bbb99.gif)




