### PR TITLE
Apollo Server renamed to GraphQL Server as of v0.4

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -87,11 +87,11 @@ app.use('/graphql', graphqlHTTP({
 app.listen(4000, () => console.log('Now browse to localhost:4000/graphql'));
 \`\`\`
 
-#### [GraphQL Server](http://dev.apollodata.com/tools/graphql-server/index.html) ([github](https://github.com/apollostack/graphql-server)) ([npm](https://www.npmjs.com/package/graphql-server))
+#### [graphql-server](http://dev.apollodata.com/tools/graphql-server/index.html) ([github](https://github.com/apollostack/graphql-server)) ([npm](https://www.npmjs.com/package/graphql-server))
 
-A GraphQL server that works with Node.js.
+A set of GraphQL server packages from Apollo that work with various Node.js HTTP frameworks (Express, Connect, Hapi, Koa etc).
 
-To run a hello world server with GraphQL Server:
+To run a hello world server with graphql-server-express:
 
 \`\`\`bash
 npm install graphql-server-express body-parser express graphql graphql-tools

--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -91,7 +91,7 @@ app.listen(4000, () => console.log('Now browse to localhost:4000/graphql'));
 
 A GraphQL server that works with Node.js.
 
-To run a hello world server with Apollo Server:
+To run a hello world server with GraphQL Server:
 
 \`\`\`bash
 npm install graphql-server-express body-parser express graphql graphql-tools

--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -87,14 +87,14 @@ app.use('/graphql', graphqlHTTP({
 app.listen(4000, () => console.log('Now browse to localhost:4000/graphql'));
 \`\`\`
 
-#### [Apollo Server](http://dev.apollodata.com/tools/apollo-server/index.html) ([github](https://github.com/apollostack/apollo-server)) ([npm](https://www.npmjs.com/package/apollo-server))
+#### [GraphQL Server](http://dev.apollodata.com/tools/graphql-server/index.html) ([github](https://github.com/apollostack/graphql-server)) ([npm](https://www.npmjs.com/package/graphql-server))
 
 A GraphQL server that works with Node.js.
 
 To run a hello world server with Apollo Server:
 
 \`\`\`bash
-npm install apollo-server body-parser express graphql graphql-tools
+npm install graphql-server-express body-parser express graphql graphql-tools
 \`\`\`
 
 Then run \`node server.js\` with this code in \`server.js\`:
@@ -102,7 +102,7 @@ Then run \`node server.js\` with this code in \`server.js\`:
 \`\`\`js
 var express = require('express');
 var bodyParser = require('body-parser');
-var { apolloExpress, graphiqlExpress } = require('apollo-server');
+var { graphqlExpress, graphiqlExpress } = require('graphql-server-express');
 var { makeExecutableSchema } = require('graphql-tools');
 
 var typeDefs = [\`
@@ -124,12 +124,12 @@ var resolvers = {
 
 var schema = makeExecutableSchema({typeDefs, resolvers});
 var app = express();
-app.use('/graphql', bodyParser.json(), apolloExpress({schema}));
+app.use('/graphql', bodyParser.json(), graphqlExpress({schema}));
 app.use('/graphiql', graphiqlExpress({endpointURL: '/graphql'}));
 app.listen(4000, () => console.log('Now browse to localhost:4000/graphiql'));
 \`\`\`
 
-Apollo Server also supports all Node.js HTTP server frameworks: Express, Connect, HAPI and Koa.
+GraphQL Server also supports all Node.js HTTP server frameworks: Express, Connect, HAPI and Koa.
 
 ### Ruby
 


### PR DESCRIPTION
Per http://dev.apollodata.com/tools/graphql-server/migration-graphql-server.html

> In version 0.4, Apollo Server has been renamed to GraphQL Server, to reduce confusion about its compatibility with other GraphQL-related packages and tools. In particular, the goal is to ensure people don’t get confused that Apollo Client only works with Apollo Server and the other way around.