### PR TITLE
Add graphql-apis list

### DIFF
--- a/site/community/Community-Resources.md
+++ b/site/community/Community-Resources.md
@@ -88,3 +88,4 @@ To explore other community-developed resources and content about GraphQL, take a
 - [Building Apollo](https://medium.com/apollo-stack)
 - [Learn GraphQL](https://learngraphql.com/basics/introduction)
 - [awesome-graphql](https://github.com/chentsulin/awesome-graphql): A fantastic community maintained collection of libraries, resources, and more.
+- [graphql-apis](https://github.com/APIs-guru/graphql-apis): A collective list of public GraphQL APIs.


### PR DESCRIPTION
added the list of public GraphQL APIs which I maintain.
It will be useful for developers that want to play or test client side tools on something beyond StarWars or GitHub APIs.
