### PR TITLE
Footer link correction

### DIFF
--- a/site/_core/Site.js
+++ b/site/_core/Site.js
@@ -68,7 +68,7 @@ export default ({ page, category, title, section, className, noSearch, children 
           </div>
           <div>
             <h5><a href="/code">Code</a></h5>
-            <a href="/code/#graphql-server-libraries">Servers</a>
+            <a href="/code/#server-libraries">Servers</a>
             <a href="/code/#graphql-clients">Clients</a>
             <a href="/code/#tools">Tools</a>
           </div>


### PR DESCRIPTION
The footer link should lead to:
http://graphql.org/code/#server-libraries
Instead of:
http://graphql.org/code/#graphql-server-libraries