### PR TITLE
Added Alumbra and Lacinia to the clojure section

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -260,6 +260,45 @@ See [the graphql-java docs](https://github.com/graphql-java/graphql-java) for mo
 
 ### Clojure
 
+#### [alumbra](https://github.com/alumbra/alumbra)
+
+A set of reuasable GraphQL components for Clojure conforming to the data structures given in [alumbra.spec](https://github.com/alumbra/alumbra.spec).
+
+\`\`\`clojure
+(require '[alumbra.core :as alumbra]
+         '[claro.data :as data])
+
+(def schema
+  "type Person { name: String!, friends: [Person!]! }
+   type QueryRoot { person(id: ID!): Person, me: Person! }
+   schema { query: QueryRoot }")
+
+(defrecord Person [id]
+  data/Resolvable
+  (resolve! [_ _]
+    {:name    (str "Person #" id)
+     :friends (map ->Person  (range (inc id) (+ id 3)))}))
+
+(def QueryRoot
+  {:person (map->Person {})
+   :me     (map->Person {:id 0})})
+
+(def app
+  (alumbra/handler
+    {:schema schema
+     :query  QueryRoot}))
+
+(defonce my-graphql-server
+  (aleph.http/start-server #'app {:port 3000}))
+\`\`\`
+
+\`\`\`bash
+$ curl -XPOST "http://0:3000" -H'Content-Type: application/json' -d'{
+  "query": "{ me { name, friends { name } } }"
+}'
+{"data":{"me":{"name":"Person #0","friends":[{"name":"Person #1"},{"name":"Person #2"}]}}}
+\`\`\`
+
 #### [graphql-clj](https://github.com/tendant/graphql-clj)
 
 A Clojure library that provides a GraphQL implementation.
@@ -285,6 +324,8 @@ Code that executes a hello world GraphQL query with \`graphql-clj\`:
 
 (executor/execute nil type-schema resolver-fn "{ hello }")
 \`\`\`
+
+  - [lacinia](https://github.com/walmartlabs/lacinia): A full implementation of the GraphQL specification that aims to maintain external compliance with the specification.
 
 ### Go
 


### PR DESCRIPTION
Alumbra and Lacinia are more commonly used and better maintained than graphql-clj at the moment. 