### PR TITLE
Document default values for query variables #294

### DIFF
--- a/site/learn/Learn-Queries.md
+++ b/site/learn/Learn-Queries.md
@@ -165,6 +165,24 @@ Variable definitions can be optional or required. In the case above, since there
 To learn more about the syntax for these variable definitions, it's useful to learn the GraphQL schema language. The schema language is explained in detail on the Schema page.
 
 
+### Default Variables
+
+Default values can also be assigned to the variables in the query by adding the default value after the type declaration. 
+
+```graphql
+query HeroNameAndFriends($episode: Episode = "JEDI") {
+  hero(episode: $episode) {
+    name
+    friends {
+      name
+    }
+  }
+}
+
+```
+When adding a default value, it is not necessary to provide any additional variables unless those values differ from the default value provided.
+
+
 ## Operation name
 
 One thing we also saw in the example above is that our query has acquired an _operation name_. Up until now, we have been using a shorthand syntax where we omit both the `query` keyword and the query name, but in production apps it's useful to use these to make our code less ambiguous.

--- a/site/learn/Learn-Queries.md
+++ b/site/learn/Learn-Queries.md
@@ -165,7 +165,7 @@ Variable definitions can be optional or required. In the case above, since there
 To learn more about the syntax for these variable definitions, it's useful to learn the GraphQL schema language. The schema language is explained in detail on the Schema page.
 
 
-### Default Variables
+### Default variables
 
 Default values can also be assigned to the variables in the query by adding the default value after the type declaration. 
 
@@ -180,7 +180,7 @@ query HeroNameAndFriends($episode: Episode = "JEDI") {
 }
 ```
 
-When a default value is provided, additional variable definitions are not necessary. The query will use the default value, unless a new value is declared. 
+When default values are provided for all variables, you can call the query without passing any variables. If any variables are passed as part of the variables dictionary, they will override the defaults. 
 
 ## Operation name
 

--- a/site/learn/Learn-Queries.md
+++ b/site/learn/Learn-Queries.md
@@ -178,10 +178,9 @@ query HeroNameAndFriends($episode: Episode = "JEDI") {
     }
   }
 }
-
 ```
-When adding a default value, it is not necessary to provide any additional variables unless those values differ from the default value provided.
 
+When a default value is provided, additional variable definitions are not necessary. The query will use the default value, unless a new value is declared. 
 
 ## Operation name
 


### PR DESCRIPTION
@stubailo I added a paragraph to the documentation for default values that can be used in query variables. Please have a look and let me know if this is what you had in mind. Thanks a bunch!