### PR TITLE
Make sure that broken syntax blows up in Travis

### DIFF
--- a/resources/build.js
+++ b/resources/build.js
@@ -32,5 +32,8 @@ async function build(filter) {
 }
 
 if (require.main === module) {
-  build().catch(error => console.error(error.stack || error));
+  build().catch(error => {
+    console.error(error.stack || error)
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Will prevent issues like this from happening again:

- https://github.com/graphql/graphql.github.io/pull/304
- https://github.com/graphql/graphql.github.io/issues/305

Note that we fail loudly in `build` but not in `watch` (where we want to give the user a chance to correct their error).

Tested by manually adding and removing syntax errors when doing `npm run build` and `npm run watch`.