### PR TITLE
Update GitHub link to reflect move out of early access

### DIFF
--- a/site/users/index.html.js
+++ b/site/users/index.html.js
@@ -29,7 +29,7 @@ var logos = [
     name: 'GitHub',
     img: 'github.png',
     isRound: true,
-    link: 'https://developer.github.com/early-access/graphql'
+    link: 'https://developer.github.com/v4/'
   },
   {
     name: 'Intuit',


### PR DESCRIPTION
Hey there!

It looks like the GitHub URL is still pointing to the Early Access link for GraphQL. Per last week's Satellite announcement, v4 is now officially live on the documentation site. 

I'm not sure if they plan to deprecate later, but I thought I'd submit this quick fix in case they do. The v4 link should be more permanent since the v3 RESTful link remains unchanged and is the source of truth. 

Blog post of the official announcement:
![screen shot 2017-05-31 at 11 21 14 pm](https://cloud.githubusercontent.com/assets/13326548/26667241/0c2ff8f2-4659-11e7-80f1-11ab31bd1c70.png)

