### PR TITLE
Add graphql-erlang to server implementations

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -344,6 +344,9 @@ Code that executes a hello world GraphQL query with \`graphql-clj\`:
   - [absinthe](https://github.com/absinthe-graphql/absinthe): GraphQL implementation for Elixir.
   - [graphql-elixir](https://github.com/graphql-elixir/graphql): An Elixir implementation of Facebook's GraphQL.
 
+### Erlang
+
+  - [graphql-erlang](https://github.com/shopgun/graphql-erlang): GraphQL implementation in Erlang.
 
 ## GraphQL Clients
 


### PR DESCRIPTION
Add a reference to ShopGun's GraphQL implementation for the server-side (written in Erlang)

As an aside: perhaps we should sort the implementation list based on the programming language. Right now, things are just added in the bottom it seems, so I've done that for this PR, but it feels a bit odd going through an index with no order :)