### PR TITLE
Order languages alphabetically on /code

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -23,6 +23,146 @@ Many different programming languages support GraphQL. This list contains some of
 
 ## Server Libraries
 
+In addition to the GraphQL [reference implementations in JavaScript](#javascript), server libraries include:
+
+- [C# / .NET](#c-net)
+- [Clojure](#clojure)
+- [Elixir](#elixir)
+- [Erlang](#erlang)
+- [Go](#go)
+- [Java](#java)
+- [JavaScript](#javascript)
+- [PHP](#php)
+- [Python](#python)
+- [Scala](#scala)
+- [Ruby](#ruby)
+
+### C# / .NET
+
+  - [graphql-dotnet](https://github.com/graphql-dotnet/graphql-dotnet): GraphQL for .NET
+  - [graphql-net](https://github.com/ckimes89/graphql-net): Convert GraphQL to IQueryable
+
+### Clojure
+
+#### [alumbra](https://github.com/alumbra/alumbra)
+
+A set of reusable GraphQL components for Clojure conforming to the data structures given in [alumbra.spec](https://github.com/alumbra/alumbra.spec).
+
+\`\`\`clojure
+(require '[alumbra.core :as alumbra]
+         '[claro.data :as data])
+
+(def schema
+  "type Person { name: String!, friends: [Person!]! }
+   type QueryRoot { person(id: ID!): Person, me: Person! }
+   schema { query: QueryRoot }")
+
+(defrecord Person [id]
+  data/Resolvable
+  (resolve! [_ _]
+    {:name    (str "Person #" id)
+     :friends (map ->Person  (range (inc id) (+ id 3)))}))
+
+(def QueryRoot
+  {:person (map->Person {})
+   :me     (map->Person {:id 0})})
+
+(def app
+  (alumbra/handler
+    {:schema schema
+     :query  QueryRoot}))
+
+(defonce my-graphql-server
+  (aleph.http/start-server #'app {:port 3000}))
+\`\`\`
+
+\`\`\`bash
+$ curl -XPOST "http://0:3000" -H'Content-Type: application/json' -d'{
+  "query": "{ me { name, friends { name } } }"
+}'
+{"data":{"me":{"name":"Person #0","friends":[{"name":"Person #1"},{"name":"Person #2"}]}}}
+\`\`\`
+
+#### [graphql-clj](https://github.com/tendant/graphql-clj)
+
+A Clojure library that provides a GraphQL implementation.
+
+Code that executes a hello world GraphQL query with \`graphql-clj\`:
+
+\`\`\`clojure
+
+(def schema "type QueryRoot {
+    hello: String
+  }")
+
+(defn resolver-fn [type-name field-name]
+  (get-in {"QueryRoot" {"hello" (fn [context parent & rest]
+                              "Hello world!")}}
+          [type-name field-name]))
+
+(require '[graphql-clj.executor :as executor])
+
+(executor/execute nil schema resolver-fn "{ hello }")
+\`\`\`
+
+  - [lacinia](https://github.com/walmartlabs/lacinia): A full implementation of the GraphQL specification that aims to maintain external compliance with the specification.
+
+### Elixir
+
+  - [absinthe](https://github.com/absinthe-graphql/absinthe): GraphQL implementation for Elixir.
+  - [graphql-elixir](https://github.com/graphql-elixir/graphql): An Elixir implementation of Facebook's GraphQL.
+
+### Erlang
+
+  - [graphql-erlang](https://github.com/shopgun/graphql-erlang): GraphQL implementation in Erlang.
+
+### Go
+
+  - [graphql-go](https://github.com/graphql-go/graphql): An implementation of GraphQL for Go / Golang.
+  - [graphql-relay-go](https://github.com/graphql-go/relay): A Go/Golang library to help construct a graphql-go server supporting react-relay.
+  - [neelance/graphql-go](https://github.com/neelance/graphql-go): An active implementation of GraphQL in Golang.
+
+### Java
+
+#### [graphql-java](https://github.com/graphql-java/graphql-java)
+
+A Java library for building GraphQL APIs.
+
+Code that executes a hello world GraphQL query with \`graphql-java\`:
+
+\`\`\`java
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLObjectType.newObject;
+
+public class HelloWorld {
+
+    public static void main(String[] args) {
+
+        GraphQLObjectType queryType = newObject()
+                        .name("helloWorldQuery")
+                        .field(newFieldDefinition()
+                                .type(GraphQLString)
+                                .name("hello")
+                                .staticValue("world"))
+                        .build();
+
+        GraphQLSchema schema = GraphQLSchema.newSchema()
+                        .query(queryType)
+                        .build();
+        Map<String, Object> result = new GraphQL(schema).execute("{hello}").getData();
+
+        System.out.println(result);
+        // Prints: {hello=world}
+    }
+}
+\`\`\`
+
+See [the graphql-java docs](https://github.com/graphql-java/graphql-java) for more information on setup.
+
 ### JavaScript
 
 #### [GraphQL.js](/graphql-js/) ([github](https://github.com/graphql/graphql-js/)) ([npm](https://www.npmjs.com/package/graphql))
@@ -131,6 +271,41 @@ app.listen(4000, () => console.log('Now browse to localhost:4000/graphiql'));
 
 GraphQL Server also supports all Node.js HTTP server frameworks: Express, Connect, HAPI and Koa.
 
+### PHP
+
+  - [graphql-php](https://github.com/webonyx/graphql-php): A PHP port of GraphQL reference implementation
+  - [graphql-relay-php](https://github.com/ivome/graphql-relay-php): A library to help construct a graphql-php server supporting react-relay.
+
+### Python
+
+#### [Graphene](http://graphene-python.org/) ([github](https://github.com/graphql-python/graphene))
+
+A Python library for building GraphQL APIs.
+
+To run a Graphene hello world script:
+
+\`\`\`bash
+pip install graphene
+\`\`\`
+
+Then run \`python hello.py\` with this code in \`hello.py\`:
+
+\`\`\`python
+import graphene
+
+class Query(graphene.ObjectType):
+  hello = graphene.String()
+
+  def resolve_hello(self, args, context, info):
+    return 'Hello world!'
+
+schema = graphene.Schema(query=Query)
+result = schema.execute('{ hello }')
+print(result.data['hello'])
+\`\`\`
+
+There are also nice bindings for [Relay](https://facebook.github.io/relay/), Django, SQLAlchemy, and Google App Engine.
+
 ### Ruby
 
 #### [graphql-ruby](https://github.com/rmosolgo/graphql-ruby)
@@ -165,36 +340,6 @@ puts Schema.execute('{ hello }')
 
 There are also nice bindings for Relay and Rails.
 
-### Python
-
-#### [Graphene](http://graphene-python.org/) ([github](https://github.com/graphql-python/graphene))
-
-A Python library for building GraphQL APIs.
-
-To run a Graphene hello world script:
-
-\`\`\`bash
-pip install graphene
-\`\`\`
-
-Then run \`python hello.py\` with this code in \`hello.py\`:
-
-\`\`\`python
-import graphene
-
-class Query(graphene.ObjectType):
-  hello = graphene.String()
-
-  def resolve_hello(self, args, context, info):
-    return 'Hello world!'
-
-schema = graphene.Schema(query=Query)
-result = schema.execute('{ hello }')
-print(result.data['hello'])
-\`\`\`
-
-There are also nice bindings for [Relay](https://facebook.github.io/relay/), Django, SQLAlchemy, and Google App Engine.
-
 ### Scala
 
 #### [Sangria](http://sangria-graphql.org/) ([github](https://github.com/sangria-graphql/sangria)): A Scala GraphQL library that supports [Relay](https://facebook.github.io/relay/).
@@ -217,138 +362,20 @@ val query = graphql"{ hello }"
 Executor.execute(schema, query) map println
 \`\`\`
 
-### Java
+## GraphQL Clients
 
-#### [graphql-java](https://github.com/graphql-java/graphql-java)
-
-A Java library for building GraphQL APIs.
-
-Code that executes a hello world GraphQL query with \`graphql-java\`:
-
-\`\`\`java
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLSchema;
-
-import static graphql.Scalars.GraphQLString;
-import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
-import static graphql.schema.GraphQLObjectType.newObject;
-
-public class HelloWorld {
-
-    public static void main(String[] args) {
-
-        GraphQLObjectType queryType = newObject()
-                        .name("helloWorldQuery")
-                        .field(newFieldDefinition()
-                                .type(GraphQLString)
-                                .name("hello")
-                                .staticValue("world"))
-                        .build();
-
-        GraphQLSchema schema = GraphQLSchema.newSchema()
-                        .query(queryType)
-                        .build();
-        Map<String, Object> result = new GraphQL(schema).execute("{hello}").getData();
-
-        System.out.println(result);
-        // Prints: {hello=world}
-    }
-}
-\`\`\`
-
-See [the graphql-java docs](https://github.com/graphql-java/graphql-java) for more information on setup.
-
-### Clojure
-
-#### [alumbra](https://github.com/alumbra/alumbra)
-
-A set of reusable GraphQL components for Clojure conforming to the data structures given in [alumbra.spec](https://github.com/alumbra/alumbra.spec).
-
-\`\`\`clojure
-(require '[alumbra.core :as alumbra]
-         '[claro.data :as data])
-
-(def schema
-  "type Person { name: String!, friends: [Person!]! }
-   type QueryRoot { person(id: ID!): Person, me: Person! }
-   schema { query: QueryRoot }")
-
-(defrecord Person [id]
-  data/Resolvable
-  (resolve! [_ _]
-    {:name    (str "Person #" id)
-     :friends (map ->Person  (range (inc id) (+ id 3)))}))
-
-(def QueryRoot
-  {:person (map->Person {})
-   :me     (map->Person {:id 0})})
-
-(def app
-  (alumbra/handler
-    {:schema schema
-     :query  QueryRoot}))
-
-(defonce my-graphql-server
-  (aleph.http/start-server #'app {:port 3000}))
-\`\`\`
-
-\`\`\`bash
-$ curl -XPOST "http://0:3000" -H'Content-Type: application/json' -d'{
-  "query": "{ me { name, friends { name } } }"
-}'
-{"data":{"me":{"name":"Person #0","friends":[{"name":"Person #1"},{"name":"Person #2"}]}}}
-\`\`\`
-
-#### [graphql-clj](https://github.com/tendant/graphql-clj)
-
-A Clojure library that provides a GraphQL implementation.
-
-Code that executes a hello world GraphQL query with \`graphql-clj\`:
-
-\`\`\`clojure
-
-(def schema "type QueryRoot {
-    hello: String
-  }")
-
-(defn resolver-fn [type-name field-name]
-  (get-in {"QueryRoot" {"hello" (fn [context parent & rest]
-                              "Hello world!")}}
-          [type-name field-name]))
-
-(require '[graphql-clj.executor :as executor])
-
-(executor/execute nil schema resolver-fn "{ hello }")
-\`\`\`
-
-  - [lacinia](https://github.com/walmartlabs/lacinia): A full implementation of the GraphQL specification that aims to maintain external compliance with the specification.
-
-### Go
-
-  - [graphql-go](https://github.com/graphql-go/graphql): An implementation of GraphQL for Go / Golang.
-  - [graphql-relay-go](https://github.com/graphql-go/relay): A Go/Golang library to help construct a graphql-go server supporting react-relay.
-  - [neelance/graphql-go](https://github.com/neelance/graphql-go): An active implementation of GraphQL in Golang.
-
-### PHP
-
-  - [graphql-php](https://github.com/webonyx/graphql-php): A PHP port of GraphQL reference implementation
-  - [graphql-relay-php](https://github.com/ivome/graphql-relay-php): A library to help construct a graphql-php server supporting react-relay.
+- [C# / .NET](#c-net-1)
+- [Java / Android](#java-android)
+- [JavaScript](#javascript-1)
+- [Swift / iOS](#swift-ios)
 
 ### C# / .NET
 
-  - [graphql-dotnet](https://github.com/graphql-dotnet/graphql-dotnet): GraphQL for .NET
-  - [graphql-net](https://github.com/ckimes89/graphql-net): Convert GraphQL to IQueryable
+  - [graphql-net-client](https://github.com/bkniffler/graphql-net-client): Basic example GraphQL client for .NET.
 
-### Elixir
+### Java / Android
 
-  - [absinthe](https://github.com/absinthe-graphql/absinthe): GraphQL implementation for Elixir.
-  - [graphql-elixir](https://github.com/graphql-elixir/graphql): An Elixir implementation of Facebook's GraphQL.
-
-### Erlang
-
-  - [graphql-erlang](https://github.com/shopgun/graphql-erlang): GraphQL implementation in Erlang.
-
-## GraphQL Clients
+  - [Apollo Android](https://github.com/apollographql/apollo-android): A strongly-typed, caching GraphQL client for Android, written in Java.
 
 ### JavaScript
 
@@ -360,20 +387,11 @@ Code that executes a hello world GraphQL query with \`graphql-clj\`:
 
   - [Apollo iOS](http://dev.apollodata.com/ios/) ([github](https://github.com/apollostack/apollo-ios)): A GraphQL client for iOS that returns results as query-specific Swift types, and integrates with Xcode to show your Swift source and GraphQL side by side, with inline validation errors.
 
-### Java / Android
-
-  - [Apollo Android](https://github.com/apollographql/apollo-android): A strongly-typed, caching GraphQL client for Android, written in Java.
-
-### C# / .NET
-
-  - [graphql-net-client](https://github.com/bkniffler/graphql-net-client): Basic example GraphQL client for .NET.
-
 ## Tools
 
   - [graphiql](https://github.com/graphql/graphiql) ([npm](https://www.npmjs.com/package/graphiql)): An interactive in-browser GraphQL IDE.
   - [libgraphqlparser](https://github.com/graphql/libgraphqlparser): A GraphQL query language parser in C++ with C and C++ APIs.
   - [Graphql Language Service](https://github.com/graphql/graphql-language-service): An interface for building GraphQL language services for IDEs (diagnostics, autocomplete etc).
-
 
 ## More Stuff
 


### PR DESCRIPTION
This puts the language sections in order as suggested in:

https://github.com/graphql/graphql.github.io/pull/332

Additionally, it adds small tables of contents at the top of each major section to make it easier to locate and jump to specific language implementations. I maintained a special call-out to the JavaScript reference implementations because we want them to be fairly prominent (this is why they were at the top in originally).

Manually tested that the links work by running a local build. Note that there is some fragility here in that the links are hand-constructed and depend on the ordering within the page (ie. the server JavaScript link it "#javascript" but the client one is "#javascript-1" because it appears further down the page); wanted to do the simplest thing for now and deal with any breakage later IFF it ever happens.