### PR TITLE
adds GraphQLList to the imports when mentioned

### DIFF
--- a/site/blog/20160502-rest-api-graphql-wrapper.md
+++ b/site/blog/20160502-rest-api-graphql-wrapper.md
@@ -51,6 +51,7 @@ Each field will consist of a return type, optional argument definitions, and a J
 
 ```js
 import {
+  GraphQLList,
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';


### PR DESCRIPTION
Noticed that GraphQLList was being used but not imported in the first example. Looking forward to using this example at work to as part of some research and development I am doing at work