### PR TITLE
Add githubql project, the first Go GraphQL client.

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -365,6 +365,7 @@ Executor.execute(schema, query) map println
 ## GraphQL Clients
 
 - [C# / .NET](#c-net-1)
+- [Go](#go-1)
 - [Java / Android](#java-android)
 - [JavaScript](#javascript-1)
 - [Swift / Objective-C iOS](#swift-objective-c-ios)
@@ -372,6 +373,10 @@ Executor.execute(schema, query) map println
 ### C# / .NET
 
   - [graphql-net-client](https://github.com/bkniffler/graphql-net-client): Basic example GraphQL client for .NET.
+
+### Go
+
+  - [githubql](https://github.com/shurcooL/githubql#readme): GraphQL client for accessing GitHub's GraphQL API, in Go, generated from schema.
 
 ### Java / Android
 


### PR DESCRIPTION
To my knowledge, this is the first GraphQL client package available for [Go](https://golang.org/).

It's still in active development, but by now, it's feature complete and functional. It has support for performing queries and mutations, including arguments, variables, aliases, inline fragments, unions, etc.

The focus of the package was to come up with a friendly, simple, powerful API for a Go GraphQL client. The history of its development and API design decisions can be seen at https://github.com/google/go-github/issues/646.

Everything specific to GitHub's GraphQL API v4 is generated from the schema, so it can be easily adapted for other GraphQL APIs. It's planned to generalize the GraphQL client generator.

It has been tested via simple test programs, as well as more advanced use cases, and comes with thorough test coverage. Its API is becoming more stable, so I think it's a good time to add it to the list of GraphQL-related code.