### PR TITLE
Add link to How to GraphQL tutorial

### DIFF
--- a/site/learn/Introduction.md
+++ b/site/learn/Introduction.md
@@ -7,7 +7,7 @@ permalink: /learn/
 next: /learn/queries/
 ---
 
-> Learn about GraphQL, how it works, and how to use it in this series of articles. Looking for documentation on how to build a GraphQL service? There are libraries to help you implement GraphQL in [many different languages](/code/).
+> Learn about GraphQL, how it works, and how to use it in this series of articles. Looking for documentation on how to build a GraphQL service? There are libraries to help you implement GraphQL in [many different languages](/code/). For an in-depth learning experience with practical tutorials, visit the [How to GraphQL](https://www.howtographql.com) fullstack tutorial website.
 
 GraphQL is a query language for your API, and a server-side runtime for executing queries by using a type system you define for your data. GraphQL isn't tied to any specific database or storage engine and is instead backed by your existing code and data.
 


### PR DESCRIPTION
I love the "learn" section of graphql.org but we often hear that people want to have a more practical getting started experience. Hopefully this is the right location to mention [How to GraphQL](https://www.howtographql.com/).