### PR TITLE
Fix misleading title in APIReference-TypeSystem.md

### DIFF
--- a/site/graphql-js/APIReference-TypeSystem.md
+++ b/site/graphql-js/APIReference-TypeSystem.md
@@ -1,5 +1,5 @@
 ---
-title: graphql/types
+title: graphql/type
 layout: ../_core/GraphQLJSLayout
 category: API Reference
 permalink: /graphql-js/type/


### PR DESCRIPTION
This plural form can kind of misleading in API section