### PR TITLE
Section operation name: provide code example, edit text, change order…

### DIFF
--- a/site/learn/Learn-Queries.md
+++ b/site/learn/Learn-Queries.md
@@ -4,7 +4,7 @@ layout: ../_core/DocsLayout
 category: Learn
 permalink: /learn/queries/
 next: /learn/schema/
-sublinks: Fields,Arguments,Aliases,Fragments,Variables,Operation Name,Directives,Mutations,Inline Fragments
+sublinks: Fields,Arguments,Aliases,Fragments,Operation Name,Variables,Directives,Mutations,Inline Fragments
 ---
 
 On this page, you'll learn in detail about how to query a GraphQL server.
@@ -124,6 +124,33 @@ fragment comparisonFields on Character {
 
 You can see how the above query would be pretty repetitive if the fields were repeated. The concept of fragments is frequently used to split complicated application data requirements into smaller chunks, especially when you need to combine lots of UI components with different fragments into one initial data fetch.
 
+## Operation name
+
+Up until now, we have been using a shorthand syntax where we omit both the `query` keyword and the query name, but in production apps it's useful to use these to make our code less ambiguous. 
+You'll need these optional parts to a GraphQL operation if you want to execute something other than a query or pass dynamic variables.
+
+Here’s an example that includes the keyword `query` as _operation type_ and `HeroNameAndFriends` as _operation name_ :
+
+```graphql
+# { "graphiql": true }
+query HeroNameAndFriends {
+  hero {
+    name
+    friends {
+      name
+    }
+  }
+}
+```
+
+The _operation type_ is either _query_, _mutation_, or _subscription_ and describes what type of operation you're intending to do.
+
+The _operation name_ is a meaningful and explicit name for your operation. It can be very useful for debugging and server-side logging reasons. 
+When something goes wrong either in your network logs or your GraphQL server, it is easier to identify a query in your codebase by name instead of trying to decipher the contents.
+Think of this just like a function name in your favorite programming language. 
+For example, in JavaScript we can easily work only with anonymous functions, but when we give a function a name, it's easier to track it down, debug our code, 
+and log when it's called. In the same way, GraphQL query and mutation names, along with fragment names, can be a useful debugging tool on the server side to identify 
+different GraphQL requests.
 
 ## Variables
 
@@ -181,13 +208,6 @@ query HeroNameAndFriends($episode: Episode = "JEDI") {
 ```
 
 When default values are provided for all variables, you can call the query without passing any variables. If any variables are passed as part of the variables dictionary, they will override the defaults. 
-
-## Operation name
-
-One thing we also saw in the example above is that our query has acquired an _operation name_. Up until now, we have been using a shorthand syntax where we omit both the `query` keyword and the query name, but in production apps it's useful to use these to make our code less ambiguous.
-
-Think of this just like a function name in your favorite programming language. For example, in JavaScript we can easily work only with anonymous functions, but when we give a function a name, it's easier to track it down, debug our code, and log when it's called. In the same way, GraphQL query and mutation names, along with fragment names, can be a useful debugging tool on the server side to identify different GraphQL requests.
-
 
 ## Directives
 


### PR DESCRIPTION
… of topics

Hi there,
in my PR, I worked on Issue #241.
* I added a code example for operation names
* and edited the texts, both referring to the suggested article ( https://dev-blog.apollodata.com/the-anatomy-of-a-graphql-query-6dffa9e9e747).
* I changed the order of the topics: Section 'Operation name' now comes before section 'Variables'. I find that easier to grasp, as the examples in 'Variables' use an operation type and name, but neither had been explained before. Therefore I also adjusted the order of topics in the nav sidebar.