### PR TITLE
Fix API Reference on return type of `execute`

### DIFF
--- a/site/graphql-js/APIReference-Execution.md
+++ b/site/graphql-js/APIReference-Execution.md
@@ -38,7 +38,9 @@ export function execute(
   contextValue?: mixed,
   variableValues?: ?{[key: string]: mixed},
   operationName?: ?string
-): Promise<ExecutionResult>
+): MaybePromise<ExecutionResult>
+
+type MaybePromise<T> = Promise<T> | T;
 
 type ExecutionResult = {
   data: ?Object;


### PR DESCRIPTION
API Reference incorrectly states that return type of `execute` is always a `Promise`
https://github.com/graphql/graphql-js/blob/8173c24dba61c5e032e4abd518729a5591b3076c/src/execution/execute.js#L147