### PR TITLE
Clarify operation type and name requirements

### DIFF
--- a/site/learn/Learn-Queries.md
+++ b/site/learn/Learn-Queries.md
@@ -126,8 +126,7 @@ You can see how the above query would be pretty repetitive if the fields were re
 
 ## Operation name
 
-Up until now, we have been using a shorthand syntax where we omit both the `query` keyword and the query name, but in production apps it's useful to use these to make our code less ambiguous. 
-You'll need these optional parts to a GraphQL operation if you want to execute something other than a query or pass dynamic variables.
+Up until now, we have been using a shorthand syntax where we omit both the `query` keyword and the query name, but in production apps it's useful to use these to make our code less ambiguous.
 
 Here’s an example that includes the keyword `query` as _operation type_ and `HeroNameAndFriends` as _operation name_ :
 
@@ -143,9 +142,9 @@ query HeroNameAndFriends {
 }
 ```
 
-The _operation type_ is either _query_, _mutation_, or _subscription_ and describes what type of operation you're intending to do.
+The _operation type_ is either _query_, _mutation_, or _subscription_ and describes what type of operation you're intending to do. The operation type is required unless you're using the query shorthand syntax, in which case you can't supply a name or variable definitions for your operation.
 
-The _operation name_ is a meaningful and explicit name for your operation. It can be very useful for debugging and server-side logging reasons. 
+The _operation name_ is a meaningful and explicit name for your operation. It is only required in multi-operation documents, but its use is encouraged because it is very helpful for debugging and server-side logging. 
 When something goes wrong either in your network logs or your GraphQL server, it is easier to identify a query in your codebase by name instead of trying to decipher the contents.
 Think of this just like a function name in your favorite programming language. 
 For example, in JavaScript we can easily work only with anonymous functions, but when we give a function a name, it's easier to track it down, debug our code, 


### PR DESCRIPTION
The current text can make it seem that an operation name is required for any mutations or subscriptions, and for any operation with variable definitions:

> Up until now, we have been using a shorthand syntax where we omit both the query keyword and the query name, but in production apps it's useful to use these to make our code less ambiguous. You'll need these optional parts to a GraphQL operation if you want to execute something other than a query or pass dynamic variables.

As far as I can tell, the spec only requires operation names in multi-operation documents:

http://facebook.github.io/graphql/October2016/#sec-Language.Operations
http://facebook.github.io/graphql/October2016/#sec-Validation.Operations

This pull request modifies the text to be more precise about the requirements for operation type and name.