### PR TITLE
Add link to quicktype in Tools section

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -431,6 +431,7 @@ Executor.execute(schema, query) map println
   - [graphiql](https://github.com/graphql/graphiql) ([npm](https://www.npmjs.com/package/graphiql)): An interactive in-browser GraphQL IDE.
   - [libgraphqlparser](https://github.com/graphql/libgraphqlparser): A GraphQL query language parser in C++ with C and C++ APIs.
   - [Graphql Language Service](https://github.com/graphql/graphql-language-service): An interface for building GraphQL language services for IDEs (diagnostics, autocomplete etc).
+  - [quicktype](https://quicktype.io) ([github](https://github.com/quicktype/quicktype)): Generate types for GraphQL queries in TypeScript, Swift, golang, C#, C++, and more.
 
 ## Services
 


### PR DESCRIPTION
quicktype generates types and helper code for GraphQL queries in Swift, C#, C++, golang, Java, and other languages.

* [Typesafe GraphQL queries with quicktype](https://blog.quicktype.io/graphql-with-quicktype/) is a blog article with more details
* [quicktype/graphql-samples](https://github.com/quicktype/graphql-samples) is a sample project that shows how to generate code for GraphQL queries in C# and TypeScript