### PR TITLE
Remove "subscriptions" for the time being

### DIFF
--- a/site/learn/Learn-Queries.md
+++ b/site/learn/Learn-Queries.md
@@ -143,7 +143,7 @@ query HeroNameAndFriends {
 }
 ```
 
-The _operation type_ is either _query_, _mutation_, or _subscription_ and describes what type of operation you're intending to do.
+The _operation type_ is either _query_ or _mutation_ and describes what type of operation you're intending to do.
 
 The _operation name_ is a meaningful and explicit name for your operation. It can be very useful for debugging and server-side logging reasons. 
 When something goes wrong either in your network logs or your GraphQL server, it is easier to identify a query in your codebase by name instead of trying to decipher the contents.


### PR DESCRIPTION
Subscriptions aren't a part of the latest stable spec (as of Feb 2018), so it is confusing for the documentation to mention this upcoming feature. This commit removes mention of subscriptions.

Right now, searching the docs for the text "subscriptions" yields no results. So a developer may think to check the specification that is linked in the table of contents, but it is not there, either. I think it is best to remove this from the docs until it is _at least_ available in the spec that the site links to (and preferably also included in a guide somewhere!)

For more, see https://github.com/facebook/graphql/issues/334

---

If this PR isn't merged, then maybe one that changes the word "either" to the phrase "one of," since "either" suggests two options 🙂 