### PR TITLE
Add Hasura to List of Services

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -441,6 +441,7 @@ Executor.execute(schema, query) map println
   - [Scaphold](https://scaphold.io) ([github](https://github.com/scaphold-io)): A BaaS (Backend as a Service) that sets you up with a GraphQL backend for your applications with many different integrations.
   - [Tipe](https://tipe.io) ([github](https://github.com/tipeio)): A SaaS (Software as a Service) content management system that allows you to create your content with powerful editing tools and access it from anywhere with a GraphQL or REST API.
   - [AWS AppSync](https://aws.amazon.com/appsync/): Fully managed GraphQL service with realtime subscriptions, offline programming & synchronization, and enterprise security features as well as fine grained authorization controls.
+  - [Hasura](https://hasura.io): A BaaS (Backend as a Service) that lets you create tables, define permissions on Postgres and query and manipulate using a GraphQL interface.
 
 ## More Stuff
 


### PR DESCRIPTION
Hasura is a BaaS (Backend as a Service) that lets you create tables, define permissions on Postgres and query and manipulate using a GraphQL interface. It also has a PaaS component which lets you deploy using `git push`

Recently launched on [ProductHunt](https://www.producthunt.com/posts/hasura-graphql-baas).