### PR TITLE
Use p instead of puts for ruby

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -361,7 +361,7 @@ Schema = GraphQL::Schema.define do
   query QueryType
 end
 
-puts Schema.execute('{ hello }')
+p Schema.execute('{ hello }')
 \`\`\`
 
 There are also nice bindings for Relay and Rails.


### PR DESCRIPTION
Environment Information 
```
RubyGems Environment:
  - RUBYGEMS VERSION: 2.6.13
  - RUBY VERSION: 2.3.3 (2016-11-21 patchlevel 222) [x86_64-darwin16]
  - INSTALLATION DIRECTORY: /Users/adityavarma/.rvm/gems/ruby-2.3.3
  - USER INSTALLATION DIRECTORY: /Users/adityavarma/.gem/ruby/2.3.0
  - RUBY EXECUTABLE: /Users/adityavarma/.rvm/rubies/ruby-2.3.3/bin/ruby
  - EXECUTABLE DIRECTORY: /Users/adityavarma/.rvm/gems/ruby-2.3.3/bin
  - SPEC CACHE DIRECTORY: /Users/adityavarma/.gem/specs
  - SYSTEM CONFIGURATION DIRECTORY: /Users/adityavarma/.rvm/rubies/ruby-2.3.3/etc
  - RUBYGEMS PLATFORMS:
    - ruby
    - x86_64-darwin-16
  - GEM PATHS:
     - /Users/adityavarma/.rvm/gems/ruby-2.3.3
     - /Users/adityavarma/.rvm/gems/ruby-2.3.3@global
  - GEM CONFIGURATION:
     - :update_sources => true
     - :verbose => true
     - :backtrace => false
     - :bulk_threshold => 1000
     - "gem" => "--no-document"
  - REMOTE SOURCES:
     - https://rubygems.org/
  - SHELL PATH:
     - /Users/adityavarma/.rvm/gems/ruby-2.3.3/bin
     - /Users/adityavarma/.rvm/gems/ruby-2.3.3@global/bin
     - /Users/adityavarma/.rvm/rubies/ruby-2.3.3/bin
     - /Users/adityavarma/.rvm/bin
     - /Users/adityavarma/google-cloud-sdk/bin
     - /usr/local/bin
     - /usr/bin
     - /bin
     - /usr/sbin
     - /sbin
     - /opt/X11/bin
     - /Applications/Postgres.app/Contents/Versions/latest/bin
     - /Users/adityavarma/.vim/bundle/vim-superman/bin

```
`Puts` is not working it is giving **output** as `#<GraphQL::Query::Result:0x007ffeb716f4a0>`
Instead of `puts`, `p` is giving output as `#<GraphQL::Query::Result @query=... @to_h={"data"=>{"hello"=>"Hello World"}} >`