### PR TITLE
Adding Hasura to GraphQL services

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -437,6 +437,7 @@ Executor.execute(schema, query) map println
   - [Apollo Engine](http://www.apollographql.com/engine/): A service for monitoring the performance and usage of your GraphQL backend.
   - [GraphCMS](https://graphcms.com/): A BaaS (Backend as a Service) that sets you up with a GraphQL backend as well as tools for content editors to work with the stored data.
   - [Graphcool](https://www.graph.cool) ([github](https://github.com/graphcool)): A BaaS (Backend as a Service) providing a GraphQL backend for your applications with a powerful web ui for managing your database and stored data.
+  - [Hasura](https://hasura.io/graphql): Create tables and get a GraphQL backend in under 60s. Works on top of Postgres that you can directly access. No initial knowledge of GraphQL required.
   - [Reindex](https://www.reindex.io/baas/) ([github](https://github.com/reindexio/reindex-js)): A BaaS (Backend as a Service) that sets you up with a GraphQL backend targeted at applications using React and Relay.
   - [Scaphold](https://scaphold.io) ([github](https://github.com/scaphold-io)): A BaaS (Backend as a Service) that sets you up with a GraphQL backend for your applications with many different integrations.
   - [Tipe](https://tipe.io) ([github](https://github.com/tipeio)): A SaaS (Software as a Service) content management system that allows you to create your content with powerful editing tools and access it from anywhere with a GraphQL or REST API.


### PR DESCRIPTION
Hasura is the easiest way to get GraphQL on Postgres 
You can tables & relationships and instantly get GraphQL endpoints without writing a single line of code.
You also have direct access to underlying Postgres if you need any customization.