### PR TITLE
Revert "Delete CNAME"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+graphql.org


### PR DESCRIPTION
It looks like in 501b5a35ba004cbede2723b908cd4a735f3758b1 the `CNAME` was removed, causing 404s:

![screen shot 2018-05-25 at 12 39 40 pm](https://user-images.githubusercontent.com/934497/40555933-be00e8b4-6018-11e8-9079-72a7179359fd.png)

In the event this was accidental, this commit reverts 501b5a35ba004cbede2723b908cd4a735f3758b1, which should cause the next page build to work.

##

/cc @JoelMarcey, @leebyron 