### PR TITLE
Change Ruby example to print JSON instead of object

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -361,7 +361,8 @@ Schema = GraphQL::Schema.define do
   query QueryType
 end
 
-puts Schema.execute('{ hello }')
+result = Schema.execute('{ hello }')
+puts result.to_json
 \`\`\`
 
 There are also nice bindings for Relay and Rails.

--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -361,8 +361,7 @@ Schema = GraphQL::Schema.define do
   query QueryType
 end
 
-result = Schema.execute('{ hello }')
-puts result.to_json
+puts Schema.execute('{ hello }').to_json
 \`\`\`
 
 There are also nice bindings for Relay and Rails.


### PR DESCRIPTION
I wondered whether changing the Ruby example of the server side code might be useful. Converting the result of `Schema.execute` to `json` before printing it renders a more readable result: `{"data":{"hello":"Hello world!"}}` rather than just the object `#<GraphQL::Query::Result:0x00007f893535cf80>`.