### PR TITLE
Remove "questions" from the purpose of the Facebook Group

### DIFF
--- a/site/community/Community-Resources.md
+++ b/site/community/Community-Resources.md
@@ -13,7 +13,7 @@ Many members of the community use Stack Overflow to ask and answer questions. [R
 
 ## Facebook Group
 
-Join the [GraphQL Facebook Group](https://www.facebook.com/groups/graphql.community/) for questions, discussion, and sharing. The GraphQL Facebook group is the preferred venue for announcements and broader discussion.
+Join the [GraphQL Facebook Group](https://www.facebook.com/groups/graphql.community/) sharing and discovering new content. The GraphQL Facebook group is the preferred venue for announcements and broader discussion.
 
 ## Twitter
 


### PR DESCRIPTION
We never approved question posts there since the group was created.
For that, StackOverflow, Slack and Discord are preferable.