### PR TITLE
Remove CNAME

### DIFF
--- a/site/CNAME
+++ b/site/CNAME
@@ -1,1 +1,0 @@
-graphql.org


### PR DESCRIPTION
Now that we use Cloudflare, the CNAME file causes an infinite redirect. Let's just remove it completely.