### PR TITLE
Renamed hot chcocolate description from service to server

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -42,7 +42,7 @@ In addition to the GraphQL [reference implementations in JavaScript](#javascript
 
   - [graphql-dotnet](https://github.com/graphql-dotnet/graphql-dotnet): GraphQL for .NET
   - [graphql-net](https://github.com/ckimes89/graphql-net): Convert GraphQL to IQueryable
-  - [Hot Chocolate](https://github.com/ChilliCream/hotchocolate): GraphQL Service for .net core and .net classic
+  - [Hot Chocolate](https://github.com/ChilliCream/hotchocolate): GraphQL Server for .net core and .net classic
 
 ### Clojure
 


### PR DESCRIPTION
changed: GraphQL Service for .net core and .net classic
to: GraphQL Server for .net core and .net classic