### PR TITLE
Fix confusing indentation in /code#Clojure

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -107,7 +107,9 @@ Code that executes a hello world GraphQL query with \`graphql-clj\`:
 (executor/execute nil schema resolver-fn "{ hello }")
 \`\`\`
 
-  - [lacinia](https://github.com/walmartlabs/lacinia): A full implementation of the GraphQL specification that aims to maintain external compliance with the specification.
+#### [lacinia](https://github.com/walmartlabs/lacinia)
+
+A full implementation of the GraphQL specification that aims to maintain external compliance with the specification.
 
 ### Elixir
 


### PR DESCRIPTION
With lacinia being a bullet point and the other projects under Clojure being
headers, it looked like lacinia was nested under graphql-clj.