### PR TITLE
fix link on variable page

### DIFF
--- a/site/learn/Learn-Queries.md
+++ b/site/learn/Learn-Queries.md
@@ -126,7 +126,7 @@ You can see how the above query would be pretty repetitive if the fields were re
 
 ### Using variables inside fragments
 
-It is possible for fragments to access variables declared in the query or mutation. See [variables](learn/queries/#variables).
+It is possible for fragments to access variables declared in the query or mutation. See [variables](#variables).
 
 ```graphql
 # { "graphiql": true }


### PR DESCRIPTION
`site/learn/Learn-Queries.md:129` was pointing to https://graphql.org/learn/queries/learn/queries/#variables 

so removing the 'learn/queries/' part corrects the link to https://graphql.org/learn/queries/#variables 

Originally noticed while reading this page https://graphql.org/learn/queries/
