### PR TITLE
Update Learn-Schema.md -- Improve Union Type Examples

### DIFF
--- a/site/learn/Learn-Schema.md
+++ b/site/learn/Learn-Schema.md
@@ -311,6 +311,7 @@ In this case, if you query a field that returns the `SearchResult` union type, y
 # { "graphiql": true}
 {
   search(text: "an") {
+    __typename
     ... on Human {
       name
       height
@@ -326,6 +327,31 @@ In this case, if you query a field that returns the `SearchResult` union type, y
   }
 }
 ```
+
+In this case, since `Human` and `Droid` share a common interface (`Character`), you can query their common fields in one place rather than having to repeat the same fields across multiple types:
+
+```graphql
+{
+  search(text: "an") {
+    __typename
+    ... on Character {
+      name
+    }
+    ... on Human {
+      height
+    }
+    ... on Droid {
+      primaryFunction
+    }
+    ... on Starship {
+      name
+      length
+    }
+  }
+}
+```
+
+Note that `name` is still specified on `Starship` because otherwise it wouldn't show up in the results given that `Starship` is not a `Character`!
 
 ### Input types
 

--- a/site/learn/Learn-Schema.md
+++ b/site/learn/Learn-Schema.md
@@ -328,7 +328,9 @@ In this case, if you query a field that returns the `SearchResult` union type, y
 }
 ```
 
-In this case, since `Human` and `Droid` share a common interface (`Character`), you can query their common fields in one place rather than having to repeat the same fields across multiple types:
+The `__typename` field resolves to a `String` which lets you differentiate different data types from each other on the client.
+
+Also, in this case, since `Human` and `Droid` share a common interface (`Character`), you can query their common fields in one place rather than having to repeat the same fields across multiple types:
 
 ```graphql
 {


### PR DESCRIPTION
This PR adds `__typename` to the query to show that union types can still be differentiated on the client and adds a second example showing common fields being queried in one spot.

There is another way to accomplish the same thing that I pointed out in this PR using fragments. Ultimately I felt like the solution targeting the common interface was cleaner and adding a note about Fragments might feel cluttered, but we can add this example if desired as well:

```graphql
{
  search(text: "an") {
    __typename
    ... on Human {
      ...CharacterProps
      height
    }
    ... on Droid {
      ...CharacterProps
      primaryFunction
    }
    ... on Starship {
      name
      length
    }
  }
}

fragment CharacterProps on Character {
  name
}
```