### PR TITLE
Fix prototype of astFromValue

### DIFF
--- a/site/graphql-js/APIReference-Utilities.md
+++ b/site/graphql-js/APIReference-Utilities.md
@@ -189,7 +189,7 @@ corresponding GraphQLType from that schema.
 ```js
 function astFromValue(
   value: any,
-  type?: ?GraphQLType
+  type: GraphQLInputType
 ): ?Value
 ```
 Produces a GraphQL Input Value AST given a JavaScript value.


### PR DESCRIPTION
There is a mismatch between what is stated in the docs and the typescript definition. From typescript definition:
```
export function astFromValue(value: any, type: GraphQLInputType): Maybe<ValueNode>;
```