### PR TITLE
Update Tutorial-Authentication.md

### DIFF
--- a/site/graphql-js/Tutorial-Authentication.md
+++ b/site/graphql-js/Tutorial-Authentication.md
@@ -9,7 +9,7 @@ next: /graphql-js/constructing-types/
 
 It's simple to use any Express middleware in conjunction with `express-graphql`. In particular, this is a great pattern for handling authentication.
 
-To use middleware with a GraphQL resolver, just use the middleware like you would with a normal Express app. The `request` object is then available as the second argument in any resolver.
+To use middleware with a GraphQL resolver, just use the middleware like you would with a normal Express app. The `request` object is then available as the third argument in any resolver.
 
 For example, let's say we wanted our server to log the IP address of every request, and we also want to write an API that returns the IP address of the caller. We can do the former with middleware, and the latter by accessing the `request` object in a resolver. Here's server code that implements this:
 
@@ -30,7 +30,7 @@ function loggingMiddleware(req, res, next) {
 }
 
 var root = {
-  ip: function (args, request) {
+  ip: function (parent, args, request) {
     return request.ip;
   }
 };


### PR DESCRIPTION
## Background 
The current GraphQL Authentication and Express Middleware documentation states the "request" object is passed as the second argument in a resolver.

However, the express-graphql (v0.7.1 ) documentation states the "request" object is passed as the third argument to resolvers. See here: https://github.com/graphql/express-graphql#combining-with-other-express-middleware

I've tested this and it appears the express-graphql documentation is correct.

## Proposed File Change
I've updated this page to match the express-graphql documentation.

Please let me know if you have any questions.