### PR TITLE
FileJet image optimization for "users" page

### DIFF
--- a/site/users/index.html.js
+++ b/site/users/index.html.js
@@ -696,7 +696,27 @@ module.exports = ({ page }) =>
           a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1
         ).map(logo =>
           <a href={logo.link} target="_blank" rel="noopener noreferrer nofollow" key={logo.name}>
-            <img src={'/users/logos/' + logo.img} title={logo.name} className={logo.isRound ? 'round' : null} />
+            <picture>
+              <source
+                media="(min-width: 1020px)"
+                srcset={
+                  "https://graphql.5gcdn.net/ext/resize_230x110shrink,auto?src=" +
+                  encodeURIComponent(
+                    "https://graphql.github.io/users/logos/" + logo.img
+                  )
+                }
+              />
+              <img
+                src={
+                  "https://graphql.5gcdn.net/ext/resize_148x72shrink,auto?src=" +
+                  encodeURIComponent(
+                    "https://graphql.github.io/users/logos/" + logo.img
+                  )
+                }
+                title={logo.name}
+                className={logo.isRound ? "round" : null}
+              />
+            </picture>
           </a>
         )}
       </div>


### PR DESCRIPTION
We at FileJet love your project so we have decided that we will help you to optimize your "users" page.

Size matters!

Hence we are caching your images by our smart CDN which resizes them based on your CSS media queries so your users won't download billboard sized images to their mobile devices ;-)

Here is your traffic (throttled for Fast 3G) without FileJet usage:

![without-filejet](https://user-images.githubusercontent.com/2583610/54866098-40c77480-4d70-11e9-9910-c3343a5f84aa.png)

And of course with using the FileJet:

![with-filejet](https://user-images.githubusercontent.com/2583610/54866097-40c77480-4d70-11e9-89da-4aba7003bf55.png)

You can find full report at [inspector.filejet.io](https://inspector.filejet.io/result/4ue6i6qgjm9o1hhaxetys8ko4qxt619r)

We also wanted to add `onError` for serving the original images but it seems that it's being removed from the DOM on compilation :disappointed: It would look something like this:

```javascript
onError={(e)=>{e.target.onerror = null; e.target.src=`https://graphql.github.io/users/logos/${logo.img}`}}
```

Since we love your product so much we are giving this to you for free :-)


Your domain (graphql.github.com) has been white-listed so you can use it at other pages as well if you wish. We can even help you implement it if you wish.


With :heart: by FileJet