### PR TITLE
move machinebox/graphql from server to client section

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -126,7 +126,6 @@ A full implementation of the GraphQL specification that aims to maintain externa
   - [graph-gophers/graphql-go](https://github.com/graph-gophers/graphql-go): An active implementation of GraphQL in Golang (was https://github.com/neelance/graphql-go).
   - [GQLGen](https://github.com/99designs/gqlgen) - Go generate based graphql server library.
   - [graphql-relay-go](https://github.com/graphql-go/relay): A Go/Golang library to help construct a graphql-go server supporting react-relay.
-  - [machinebox/graphql](https://github.com/machinebox/graphql): An elegant low-level HTTP client for GraphQL.
   - [samsarahq/thunder](https://github.com/samsarahq/thunder): A GraphQL implementation with easy schema building, live queries, and batching.
 
 ### Groovy 
@@ -459,6 +458,7 @@ Executor.execute(schema, query) map println
 ### Go
 
   - [graphql](https://github.com/shurcooL/graphql#readme): A GraphQL client implementation in Go.
+  - [machinebox/graphql](https://github.com/machinebox/graphql): An elegant low-level HTTP client for GraphQL.
 
 ### Java / Android
 


### PR DESCRIPTION
This Go GraphQL client was added in PR #431 to the section for
Go GraphQL server libraries. Move it to the section for Go GraphQL
client libraries instead.

/cc @matryer