### PR TITLE
add trailing slashes to prevent github.io 301, splat for query params

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -1,1 +1,2 @@
-/swapi-graphql  https://graphql.github.io/swapi-graphql  200
+/swapi-graphql  https://graphql.github.io/swapi-graphql/   200
+/swapi-graphql/* https://graphql.github.io/swapi-graphql/:splat   200


### PR DESCRIPTION
 Ope! After talking to Netlify support who's been super helpful, he pointed out that we are pointing to a githubpages path that forces a 301 redirect. Adding the trailing slash should fix this, as github.io will send a 200 for graphql.github.io/swapi-graphql/ and a 301 for graphql.github.io/swapi-graphql to the latter.

(added) a splat for QPs as well, such as `graphql.org/swapi-graphql/?query=234234234`.
this should hopefully fix legacy links, where folks have GraphQL query examples/etc that point to this domain