### PR TITLE
better redirects using 301 HTTP code

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -1,2 +1,25 @@
-/swapi-graphql  https://graphql.github.io/swapi-graphql/   200
-/swapi-graphql/* https://graphql.github.io/swapi-graphql/:splat   200
+# 200 = reverse proxy rules 
+# https://www.netlify.com/docs/redirects/#rewrites-and-proxying
+
+/swapi-graphql        https://graphql.github.io/swapi-graphql/          200
+/swapi-graphql/*      https://graphql.github.io/swapi-graphql/:splat    200
+
+# 301 = permanent redirects
+# https://www.netlify.com/docs/redirects/#http-status-codes
+
+/docs/api-reference-errors            /graphql-js/error/                301
+/docs/api-reference-execution         /graphql-js/exection/             301
+/docs/api-reference-express-graphql   /graphql-js/express-graphql/      301
+/docs/api-reference-graphql           /graphql-js/graphql/              301
+/docs/api-reference-language          /graphql-js/language/             301
+/docs/api-reference-type-system       /graphql-js/type/                 301
+/docs/api-reference-type-utilities    /graphql-js/utilities/            301
+/docs/api-reference-type-validation   /graphql-js/validation/           301
+/docs/getting-started                 /learn/                           301
+/docs/intro                           /learn/                           301
+/docs/introspection                   /learn/introspection/             301
+/docs/queries                         /learn/queries/                   301
+/docs/typesystem                      /learn/schema/                    301
+/docs/validation                      /learn/validation/                301
+/docs/videos                          /community/#videos                301
+/help                                 /community/                       301

--- a/site/docs/api-reference-errors/index.html.js
+++ b/site/docs/api-reference-errors/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/graphql-js/error/" />

--- a/site/docs/api-reference-execution/index.html.js
+++ b/site/docs/api-reference-execution/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/graphql-js/execution/" />

--- a/site/docs/api-reference-express-graphql/index.html.js
+++ b/site/docs/api-reference-express-graphql/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/graphql-js/express-graphql/" />

--- a/site/docs/api-reference-graphql/index.html.js
+++ b/site/docs/api-reference-graphql/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/graphql-js/graphql/" />

--- a/site/docs/api-reference-language/index.html.js
+++ b/site/docs/api-reference-language/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/graphql-js/language/" />

--- a/site/docs/api-reference-type-system/index.html.js
+++ b/site/docs/api-reference-type-system/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/graphql-js/type/" />

--- a/site/docs/api-reference-type-utilities/index.html.js
+++ b/site/docs/api-reference-type-utilities/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/graphql-js/utilities/" />

--- a/site/docs/api-reference-type-validation/index.html.js
+++ b/site/docs/api-reference-type-validation/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/graphql-js/validation/" />

--- a/site/docs/getting-started/index.html.js
+++ b/site/docs/getting-started/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/learn" />

--- a/site/docs/intro/index.html.js
+++ b/site/docs/intro/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/learn" />

--- a/site/docs/introspection/index.html.js
+++ b/site/docs/introspection/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/learn/introspection/" />

--- a/site/docs/queries/index.html.js
+++ b/site/docs/queries/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/learn/queries/" />

--- a/site/docs/typesystem/index.html.js
+++ b/site/docs/typesystem/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/learn/schema/" />

--- a/site/docs/validation/index.html.js
+++ b/site/docs/validation/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/learn/validation/" />

--- a/site/docs/videos/index.html.js
+++ b/site/docs/videos/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../../_core/Redirect')
-export default () => <Redirect to="/community/#videos" />

--- a/site/help/index.html.js
+++ b/site/help/index.html.js
@@ -1,3 +1,0 @@
-var React = require('react')
-var Redirect = require('../_core/Redirect')
-export default () => <Redirect to="/community/" />


### PR DESCRIPTION
handy as a point of reference, and cleans up the filesystem a bit too

now that we have `_redirects` in place and we know its working, I thought I'd go all out.

there was _almost_ a chance to do this more dynamically, but there were enough subtle differences that i made it very static

believe it or not, I read somewhere that google does indeed handle these soft JS redirects like they're 301's sometimes! poor google :/

should I also drop the Redirect.js react component, because it's no longer used? maybe document somewhere in Contributing.md how to add redirects too?