### PR TITLE
appointy/jaal - develop spec compliant GraphQL servers in go

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -128,6 +128,7 @@ A full implementation of the GraphQL specification that aims to maintain externa
   - [graphql-relay-go](https://github.com/graphql-go/relay): A Go/Golang library to help construct a graphql-go server supporting react-relay.
   - [machinebox/graphql](https://github.com/machinebox/graphql): An elegant low-level HTTP client for GraphQL.
   - [samsarahq/thunder](https://github.com/samsarahq/thunder): A GraphQL implementation with easy schema building, live queries, and batching.
+  - [appointy/jaal](https://github.com/appointy/jaal): Develop spec compliant GraphQL servers in Go.
 
 ### Groovy 
 


### PR DESCRIPTION
Added repository [Jaal](https://github.com/appointy/jaal) in Go server libraries list.