### PR TITLE
chore: update DEN meetup to reflect new name + URL

### DIFF
--- a/site/community/Community-Events.md
+++ b/site/community/Community-Events.md
@@ -41,7 +41,7 @@ GraphQL conference organized by Apollo.
 - [GraphQL Columbus](https://www.meetup.com/GraphQL-Columbus/)
 - [GraphQL Vancouver](https://www.meetup.com/GraphQL-Vancouver/)
 - [GraphQL Minneapolis](https://www.meetup.com/GraphQL-MN/)
-- [GraphQL Denver/Boulder](https://www.meetup.com/GraphQL-Denver-Boulder-Meetup/)
+- [GraphQL Denver](https://www.meetup.com/graphql-denver)
 - [GraphQL By the Bay (San Francisco)](https://www.meetup.com/graphql-by-the-bay/)
 
 ### South America


### PR DESCRIPTION
We are working on revitalizing the GraphQL meetup in Denver, and wanted to update the docs here to reflect the new name and focus.