### PR TITLE
Schemas and Types: minor fixes

### DIFF
--- a/site/learn/Learn-Schema.md
+++ b/site/learn/Learn-Schema.md
@@ -68,7 +68,7 @@ type Starship {
 }
 ```
 
-All arguments are named. Unlike languages like JavaScript and Python where functions take a list of ordered arguments, all arguments in GraphQL are passed by name specifically. In this case, the `length` field has one defined argument, `unit`.
+All arguments are named. Unlike languages like JavaScript and PHP where functions take a list of ordered arguments, all arguments in GraphQL are passed by name specifically. In this case, the `length` field has one defined argument, `unit`.
 
 Arguments can be either required or optional. When an argument is optional, we can define a _default value_ - if the `unit` argument is not passed, it will be set to `METER` by default.
 

--- a/site/learn/Learn-Schema.md
+++ b/site/learn/Learn-Schema.md
@@ -233,8 +233,8 @@ For example, you could have an interface `Character` that represents any charact
 interface Character {
   id: ID!
   name: String!
-  friends: [Character]
-  appearsIn: [Episode]!
+  friends: [Character!]
+  appearsIn: [Episode!]!
 }
 ```
 
@@ -246,17 +246,17 @@ For example, here are some types that might implement `Character`:
 type Human implements Character {
   id: ID!
   name: String!
-  friends: [Character]
-  appearsIn: [Episode]!
-  starships: [Starship]
+  friends: [Character!]
+  appearsIn: [Episode!]!
+  starships: [Starship!]
   totalCredits: Int
 }
 
 type Droid implements Character {
   id: ID!
   name: String!
-  friends: [Character]
-  appearsIn: [Episode]!
+  friends: [Character!]
+  appearsIn: [Episode!]!
   primaryFunction: String
 }
 ```


### PR DESCRIPTION
Python supports named arguments

```python
def test(a, b, c):
  print("a={0} b={1} c={2}".format(a, b, c))

test(b="World", c="Yeah!", a="Hello")
```

https://repl.it/repls/HarmlessRespectfulCodegeneration