### PR TITLE
[easy] Capitalize .NET

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -42,7 +42,7 @@ In addition to the GraphQL [reference implementations in JavaScript](#javascript
 
   - [graphql-dotnet](https://github.com/graphql-dotnet/graphql-dotnet): GraphQL for .NET
   - [graphql-net](https://github.com/ckimes89/graphql-net): Convert GraphQL to IQueryable
-  - [Hot Chocolate](https://github.com/ChilliCream/hotchocolate): GraphQL Server for .net core and .net classic
+  - [Hot Chocolate](https://github.com/ChilliCream/hotchocolate): GraphQL Server for .NET core and .NET classic
 
 ### Clojure
 


### PR DESCRIPTION
It's `.NET`, not `.net`.