### PR TITLE
GraphQl Java Generator contribution as a GraphQL Client and Server Tool

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -195,6 +195,23 @@ public class HelloWorld {
 
 See [the graphql-java docs](https://github.com/graphql-java/graphql-java) for more information on setup.
 
+#### [GraphQL Java Generator](https://github.com/graphql-java-generator)
+
+GraphQL Java Generator is a tool that generates Java code to speed up development for __Client	__ and **Server** of GraphQL APIs:
+
+* GraphQL Java client: it generates the Java classes that call the GraphQL endpoint, and the POJO that will contain the data returned by the server. 
+The GraphQL endpoint can then be queried by using a simple call to a Java method (see sample below)
+
+* GraphQL Java server: it is based on [graphql-java](https://github.com/graphql-java/graphql-java) (listed here above). It generates all the boilerplate code. 
+You'll only have to implement what's specific to your server, which are the joins between the GraphQL types.
+
+GraphQL Java Generator is available as a [Maven Plugin](https://graphql-maven-plugin-project.graphql-java-generator.com/index.html).
+A Gradle plugin is coming soon.
+
+Please note that GraphQL Java Generator is an accelerator: the generated code doesn’t depend on any library specific to GraphQL Java Generator. 
+So, it  helps you to start building application based on graphql-java. Once the code is generated, you can decide to manually edit it as any standard java application, and get rid of GraphQL Java Generator. 
+Of course you can, and should, according to us :), continue using GraphQL Java Generator when your projet evolves. 
+
 ### JavaScript
 
 #### [GraphQL.js](/graphql-js/) ([github](https://github.com/graphql/graphql-js/)) ([npm](https://www.npmjs.com/package/graphql))
@@ -465,6 +482,8 @@ Executor.execute(schema, query) map println
   - [Apollo Android](https://github.com/apollographql/apollo-android): A strongly-typed, caching GraphQL client for Android, written in Java.
 
   - [Nodes](https://github.com/americanexpress/nodes): A GraphQL JVM Client designed for constructing queries from standard model definitions. By American Express.
+  
+  - [GraphQL Java Generator](https://github.com/graphql-java-generator): it generates the Java classes that call the GraphQL endpoint, and the POJO that will contain the data returned by the server. 
 
 ### JavaScript
 


### PR DESCRIPTION
Hello,

  I worked on a project to accelerate development for Java Developper, when creating apps for both the Client and Server side of GraphQL.

  The attached Pull Request add in the "site/code/index.html.js" file, some information about it. 

I added a quick description in the server part. And a line in the Client part.
With links toward the relevant pages.

I'll be happy if this Pull Request is taken into account, as I think that GraphQL Java Generator can help Java people to use GraphQL.

Regards
Etienne