### PR TITLE
Berlin Conf date has passed and is no longer upcoming

### DIFF
--- a/site/community/Community-Events.md
+++ b/site/community/Community-Events.md
@@ -8,14 +8,6 @@ sublinks: Upcoming Events,Meetups
 
 ## Upcoming Events
 
-### GraphQL Conf Berlin
-
-- **Date:** June 20-21, 2019
-- **Location:** Berlin, Germany
-- **Link:** https://www.graphqlconf.org/
-
-GraphQL Conf Berlin is the world's biggest GraphQL community conference. It's a non-profit conference with speakers from all around the world. Learn about GraphQL best practices from industry experts and become part of the thriving GraphQL community.
-
 ### GraphQL Summit
 
 - **Date:** October 29-31, 2019


### PR DESCRIPTION
- I updated to remove berlin from the upcoming conf list as it is no longer upcoming. Should historical conference information live somewhere?