### PR TITLE
swap languages to get proper alphabetical order

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -35,8 +35,8 @@ In addition to the GraphQL [reference implementations in JavaScript](#javascript
 - [JavaScript](#javascript)
 - [PHP](#php)
 - [Python](#python)
-- [Scala](#scala)
 - [Ruby](#ruby)
+- [Scala](#scala)
 
 ### C# / .NET
 
@@ -129,13 +129,13 @@ A full implementation of the GraphQL specification that aims to maintain externa
   - [machinebox/graphql](https://github.com/machinebox/graphql): An elegant low-level HTTP client for GraphQL.
   - [samsarahq/thunder](https://github.com/samsarahq/thunder): A GraphQL implementation with easy schema building, live queries, and batching.
 
-### Groovy 
+### Groovy
 
 #### [gorm-graphql](https://github.com/grails/gorm-graphql/)
 
 **Core Library** - The GORM GraphQL library provides functionality to generate a GraphQL schema based on your GORM entities. In addition to mapping domain classes to a GraphQL schema, the core library also provides default implementations of "data fetchers" to query, update, and delete data through executions of the schema.
 
-**Grails Plugin** - In a addition to the Core Library, the GORM GraphQL Grails Plugin: 
+**Grails Plugin** - In a addition to the Core Library, the GORM GraphQL Grails Plugin:
 
 - Provides a controller to receive and respond to GraphQL requests through HTTP, based on their guidelines.
 - Generates the schema at startup with spring bean configuration to make it easy to extend.
@@ -145,7 +145,7 @@ A full implementation of the GraphQL specification that aims to maintain externa
 
 See [the documentation](https://grails.github.io/gorm-graphql/latest/guide/index.html) for more information.
 
-#### [GQL](https://grooviter.github.io/gql/) 
+#### [GQL](https://grooviter.github.io/gql/)
 
 GQL is a Groovy library for GraphQL
 


### PR DESCRIPTION
This PR changes order of languages a bit to make it sorted. The rest of the list is alphabetically ordered but Ruby (presumably incorrectly) goes after Scala. This also conforms with the order the libraries descriptions go below.