### PR TITLE
Add juniper Rust for server libraries

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -419,7 +419,7 @@ There are also nice bindings for Relay and Rails.
 
 ### Rust
 
-#### [graphql-rust/juniper](https://github.com/graphql-rust/juniper): GraphQL server library for Rust
+ - [graphql-rust/juniper](https://github.com/graphql-rust/juniper): GraphQL server library for Rust
 
 ### Scala
 

--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -37,6 +37,7 @@ In addition to the GraphQL [reference implementations in JavaScript](#javascript
 - [PHP](#php)
 - [Python](#python)
 - [Ruby](#ruby)
+- [Rust](#rust)
 - [Scala](#scala)
 
 ### C# / .NET
@@ -415,6 +416,10 @@ puts Schema.execute('{ hello }').to_json
 \`\`\`
 
 There are also nice bindings for Relay and Rails.
+
+### Rust
+
+#### [graphql-rust/juniper](https://github.com/graphql-rust/juniper): GraphQL server library for Rust
 
 ### Scala
 


### PR DESCRIPTION
juniper is currently on of the most active and supported libraries for running a GraphQL server in Rust.

https://github.com/graphql-rust/juniper