### PR TITLE
Adding a reference to GraphQLite PHP library

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -381,6 +381,43 @@ class Greeting
 
 Other API Platform features include data validation, authentication, authorization, deprecations, cache and GraphiQL integration.
 
+#### [GraphQLite](https://graphqlite.thecodingmachine.io) ([github](https://github.com/thecodingmachine/graphqlite))
+
+GraphQLite is a library that offers an annotations-based syntax for GraphQL schema definition.
+It is framework agnostic with bindings available for Symfony and Laravel.
+
+This code declares a "product" query and a "Product" Type:
+
+\`\`\`php
+class ProductController
+{
+    /**
+     * @Query()
+     */
+    public function product(string $id): Product
+    {
+        // Some code that looks for a product and returns it.
+    }
+}
+
+/**
+ * @Type()
+ */
+class Product
+{
+    /**
+     * @Field()
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    // ...
+}
+\`\`\`
+
+Other GraphQLite features include validation, security, error handling, loading via data-loader pattern...
+
 #### [Siler](https://siler.leocavalcante.com/graphql/) ([github](https://github.com/leocavalcante/siler))
 
 Siler is a PHP library powered with high-level abstractions to work with GraphQL.


### PR DESCRIPTION
Adds a reference to [GraphQLite](https://graphqlite.thecodingmachine.io), a PHP library to declare a GraphQL schema using annotations.