### PR TITLE
New swapi-graphql service using netlify functions

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -1,3 +1,5 @@
 /swapi-graphql  https://swapi-graphql.netlify.com   200
 /swapi-graphql/* https://swapi-graphql.netlify.com/:splat   200
+
 /swapi-graphql/graphql https://swapi-graphql.netlify.com/.netlify/functions/index 200
+/swapi-graphql/graphql/* https://swapi-graphql.netlify.com/.netlify/functions/index/:splat 200

--- a/site/_redirects
+++ b/site/_redirects
@@ -1,2 +1,3 @@
-/swapi-graphql  https://graphql.github.io/swapi-graphql/   200
-/swapi-graphql/* https://graphql.github.io/swapi-graphql/:splat   200
+/swapi-graphql  https://swapi-graphql.netlify.com   200
+/swapi-graphql/* https://swapi-graphql.netlify.com/:splat   200
+/swapi-graphql/graphql https://swapi-graphql.netlify.com/.netlify/functions/index 200


### PR DESCRIPTION
Now we can merge this PR, and https://swapi-graphql.netlify.com is live 🌍 at graphiql.org/swapi-graphql :D

here's where you can learn about the new features:
https://github.com/graphql/swapi-graphql/pull/162

I'm pretty sure the order of the last two rules will be fine. If the last one doesn't work, it will still work

```
/swapi-graphql/graphql https://swapi-graphql.netlify.com/.netlify/functions/index 200
```
this just 200 redirects (non permanent?) which essentially is netlify terms for what nginx is a proxy_path

so this will just make `graphiql.org/swapi-graphql/graphql` an alias for the lambda endpoint. see the PR's develop preview before it's merged if you want to see that default lambda path in action for yourself