### PR TITLE
Revert "New swapi-graphql service using netlify functions"

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -1,5 +1,2 @@
-/swapi-graphql  https://swapi-graphql.netlify.com   200
-/swapi-graphql/* https://swapi-graphql.netlify.com/:splat   200
-
-/swapi-graphql/graphql https://swapi-graphql.netlify.com/.netlify/functions/index 200
-/swapi-graphql/graphql/* https://swapi-graphql.netlify.com/.netlify/functions/index/:splat 200
+/swapi-graphql  https://graphql.github.io/swapi-graphql/   200
+/swapi-graphql/* https://graphql.github.io/swapi-graphql/:splat   200


### PR DESCRIPTION
Reverts graphql/graphql.github.io#800

This worked locally with `netlify dev` but the redirect doesn't seem to be working at all