### PR TITLE
remove / update dead links

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -588,8 +588,6 @@ Executor.execute(schema, query) map println
   - [Apollo Graph Manager](https://engine.apollographql.com): A cloud service for monitoring the performance and usage of your GraphQL backend.
   - [GraphCMS](https://graphcms.com/): A BaaS (Backend as a Service) that sets you up with a GraphQL backend as well as tools for content editors to work with the stored data.
   - [Prisma](https://www.prisma.io) ([github](https://github.com/prisma)): A BaaS (Backend as a Service) providing a GraphQL backend for your applications with a powerful web ui for managing your database and stored data.
-  - [Reindex](https://www.reindex.io/baas/) ([github](https://github.com/reindexio/reindex-js)): A BaaS (Backend as a Service) that sets you up with a GraphQL backend targeted at applications using React and Relay.
-  - [Scaphold](https://scaphold.io) ([github](https://github.com/scaphold-io)): A BaaS (Backend as a Service) that sets you up with a GraphQL backend for your applications with many different integrations.
   - [Tipe](https://tipe.io) ([github](https://github.com/tipeio)): A SaaS (Software as a Service) content management system that allows you to create your content with powerful editing tools and access it from anywhere with a GraphQL or REST API.
   - [AWS AppSync](https://aws.amazon.com/appsync/): Fully managed GraphQL service with realtime subscriptions, offline programming & synchronization, and enterprise security features as well as fine grained authorization controls.
   - [Hasura](https://hasura.io): A BaaS (Backend as a Service) that lets you create tables, define permissions on Postgres and query and manipulate using a GraphQL interface.

--- a/site/community/Community-Resources.md
+++ b/site/community/Community-Resources.md
@@ -25,7 +25,6 @@ Here are some helpful accounts to follow:
 - [@GraphQLStackOverflow](https://twitter.com/GraphQLatSO)
 - [@apollographql](https://twitter.com/apollographql)
 - [@prisma](https://twitter.com/prisma)
-- [@ScapholdDotIO](https://twitter.com/ScapholdDotIO)
 
 ## IRC
 
@@ -42,9 +41,7 @@ Join #graphql on the [ReactiFlux Discord](http://join.reactiflux.com/).
 
 - [**#general** on GraphQL](https://graphql.slack.com/messages/general/). [Get your invite here!](https://graphql-slack.herokuapp.com/)
 - [Apollo Slack](http://apollostack.com/#slack)
-- [Reindex Slack](http://slack.reindex.io/)
 - [Graphcool Slack](https://slack.graph.cool/)
-- [Scaphold.io Slack](http://slack.scaphold.io/)
 
 ## Blogs
 
@@ -116,14 +113,7 @@ To explore other community-developed resources and content about GraphQL, take a
 
 - [Exploring GraphQL: A Query Language For APIs](https://www.edx.org/course/exploring-graphql-a-query-language-for-apis): A free 7 week edX course
 - [How to GraphQL](https://www.howtographql.com): The Fullstack Tutorial for GraphQL
-- [Building Apollo](https://dev-blog.apollodata.com/)
-- [Learn GraphQL](https://learngraphql.com/basics/introduction)
+- [Building Apollo](https://blog.apollographql.com)
 - [awesome-graphql](https://github.com/chentsulin/awesome-graphql): A fantastic community maintained collection of libraries, resources, and more.
 - [graphql-apis](https://github.com/APIs-guru/graphql-apis): A collective list of public GraphQL APIs.
-- [Graphcool Blog](https://www.graph.cool/blog/)
-- [Learn Apollo](https://www.learnapollo.com/): A hands-on tutorial for Apollo GraphQL Client (for React, ReactNative, Exponent, Angular, Vue & iOS)
-- [Learn Relay](https://www.learnrelay.org): A comprehensive introduction to Relay (includes video tutorials)
-- [Scaphold Community](https://scaphold.io/community/): Resources to help you launch a production app with GraphQL
-- [GraphQL World](https://graphql-world.com): Global community of GraphQL developers and events
-- [GraphQL Talks](https://www.graph.cool/talks/): Find & Watch the best GraphQL Talks
 - [Basically, Full-stack GraphQL](https://github.com/TejasQ/basically-fullstack-graphql): A code-based introduction to working with GraphQL on the client _and_ server in plain English


### PR DESCRIPTION
This PR removes and updates links that are not working, not active anymore or redirecting to a different URL.

Here are some notes with reasoning.
- Scaphold BaaS isn't active anymore. The link doesn't work and their open source code isn't updated anymore.
- Reindex has [discontinued their BaaS](https://www.reindex.io/blog/discontinuing-backend-as-a-service/) from 2017, the link gives a 404 and they are not working on the open source code.
- Removed their twitter / slack links which aren't active as well
- Updated Apollo blog link
- graph.cool/blog redirects.
- learngraphql.com doesn't work
- graphql-world.com doesn't work
- graph.cool/talks doesn't work
- learnapollo.com & learnrelay.org both redirect to howtographql.com which is already listed at the top.