### PR TITLE
Fixes CodeMirror ScrollBars

### DIFF
--- a/site/_css/codemirror.less
+++ b/site/_css/codemirror.less
@@ -178,15 +178,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   z-index: 6;
   display: none;
 }
-.CodeMirror-vscrollbar {
-  right: 0; top: 0;
-  overflow-x: hidden;
-  overflow-y: scroll;
-}
-.CodeMirror-hscrollbar {
-  bottom: 0; left: 0;
-  overflow-y: hidden;
-  overflow-x: scroll;
+.CodeMirror-scroll {
+  overflow: hidden;
 }
 .CodeMirror-scrollbar-filler {
   right: 0; bottom: 0;


### PR DESCRIPTION
Fixes:  #835 

The CodeMirror scrollbars have been hidden without tampering with the scroll functionality. These provide a more cleaner and focused UI. 
The code has been tested on the current versions of Firefox, Edge and Chrome.

__Screenshots__
![Fixed-Scrollbars](https://user-images.githubusercontent.com/41413622/75096042-48ffe380-55c1-11ea-8566-8dbc1acc6008.gif)
