### PR TITLE
Fix #831 - Search bar is getting out of the navbar when selected

### DIFF
--- a/site/_css/algolia.less
+++ b/site/_css/algolia.less
@@ -27,7 +27,7 @@
     transition: width 0.2s ease-out;
 
     &:focus {
-      width: 300px;
+      width: 250px;
     }
   }
 


### PR DESCRIPTION
Fix #831 
![Screenshot 2020-02-23 at 3 37 35 PM](https://user-images.githubusercontent.com/31184591/75110291-78126580-5652-11ea-99ec-de92be63dae6.png)
