### PR TITLE
Searchbarfix

### DIFF
--- a/site/_css/algolia.less
+++ b/site/_css/algolia.less
@@ -25,9 +25,17 @@
     padding: 0 10px 0 35px;
     width: 180px;
     transition: width 0.2s ease-out;
+    float: right;
 
-    &:focus {
-      width: 300px;
+    @media screen and (min-width: 1021px) and (max-width: 1065px){
+      &:focus {
+        width: 180px
+      }
+    }
+    @media screen and (min-width: 1065px){
+      &:focus {
+        width: 100%;
+      }
     }
   }
 

--- a/site/_css/index.less
+++ b/site/_css/index.less
@@ -125,6 +125,9 @@ body.index {
         display: block;
         width: 90px;
         height: 90px;
+        @media screen and (max-width: 768px) {
+          margin-top: 3rem;
+        }
       }
     }
 

--- a/site/_css/index.less
+++ b/site/_css/index.less
@@ -125,9 +125,6 @@ body.index {
         display: block;
         width: 90px;
         height: 90px;
-        @media screen and (max-width: 768px) {
-          margin-top: 3rem;
-        }
       }
     }
 


### PR DESCRIPTION
Regarding https://github.com/graphql/graphql.github.io/issues/831 instead of fixing the size of search bar I've made it dynamic. 

There were 3 cases for various screen widths
<ol>
 <li><b>1021px - 1065px</b> <br/> Not altering the width otherwise search bar will pop back into another line
 
![Screenshot from 2020-02-23 20-04-01](https://user-images.githubusercontent.com/35224521/75114058-e5d18800-5678-11ea-80b1-7629da23aef5.png)

 </li>
 <li><b>1065px and above</b> <br/> Expanding search bar to 100% width of its containing element

![Screenshot from 2020-02-23 20-03-26](https://user-images.githubusercontent.com/35224521/75114064-ee29c300-5678-11ea-993c-e3e18929df1f.png)

</li>
 <li><b>under 1021px</b> <br/> NA</li>
</ol>
