### PR TITLE
Update Learn-Queries.md

### DIFF
--- a/site/learn/Learn-Queries.md
+++ b/site/learn/Learn-Queries.md
@@ -173,7 +173,7 @@ query HeroNameAndFriends {
 The _operation type_ is either _query_, _mutation_, or _subscription_ and describes what type of operation you're intending to do. The operation type is required unless you're using the query shorthand syntax, in which case you can't supply a name or variable definitions for your operation.
 
 The _operation name_ is a meaningful and explicit name for your operation. It is only required in multi-operation documents, but its use is encouraged because it is very helpful for debugging and server-side logging. 
-When something goes wrong either in your network logs or your GraphQL server, it is easier to identify a query in your codebase by name instead of trying to decipher the contents.
+When something goes wrong either in your network or your GraphQL server, it is easier to identify a query in your codebase by name instead of trying to decipher the contents.
 Think of this just like a function name in your favorite programming language. 
 For example, in JavaScript we can easily work only with anonymous functions, but when we give a function a name, it's easier to track it down, debug our code, 
 and log when it's called. In the same way, GraphQL query and mutation names, along with fragment names, can be a useful debugging tool on the server side to identify 


### PR DESCRIPTION
In sentence

> When something goes wrong either in your network *logs* or your GraphQL server, it is easier to identify a query in your codebase by name instead of trying to decipher the contents.

Removed the word "logs" because it looks like it doesn't belong to this sentence.