### PR TITLE
navbar error on small screens fixed

### DIFF
--- a/site/_css/index.less
+++ b/site/_css/index.less
@@ -111,6 +111,9 @@ body.index {
       animation: fade 1.2s ease-in-out;
       animation-fill-mode: both;
       margin-right: 18px;
+      @media screen and (max-width: 688px){
+        padding-top: 55px;
+      }
 
       h1 {
         color: @rhodamine-color;


### PR DESCRIPTION
"The navbar merging with the logo" error starts occurring at **width: 688px and less**, this error is solved by adding a media query statement. 

### Original website - 

![Screenshot (154)](https://user-images.githubusercontent.com/43211861/76116510-22559a00-6010-11ea-8a11-56c25040c01b.png)
![Screenshot (155)](https://user-images.githubusercontent.com/43211861/76116531-2a153e80-6010-11ea-9fd6-0355d41fa2e1.png)

### After fixing - 

![Screenshot (156)](https://user-images.githubusercontent.com/43211861/76116844-aad43a80-6010-11ea-8486-3c9593e53db4.png)
![Screenshot (157)](https://user-images.githubusercontent.com/43211861/76116854-ae67c180-6010-11ea-90e6-382a4f9e23dd.png)
