### PR TITLE
show active status on navbar

### DIFF
--- a/site/_core/HeaderLinks.js
+++ b/site/_core/HeaderLinks.js
@@ -18,7 +18,7 @@ const links = [
   { section: 'landscape', text: 'Landscape', href: 'https://l.graphql.org/' },
 ];
 
-export default ({ section }) =>
+export default ({ section, activeUrl }) => {
   <nav>
     {links.map(link =>
       <a
@@ -26,8 +26,10 @@ export default ({ section }) =>
         href={link.href}
         target={link.href.slice(0, 4) === 'http' ? '_blank' : null}
         rel={link.href.slice(0, 4) === 'http' ? 'noopener noreferrer' : null}
-        className={link.section === section ? 'active' : null}>
+        className={(link.section === section || activeUrl && activeUrl.startsWith(link.href)) ? 'active' : null}
+      >
         {link.text}
       </a>
     )}
   </nav>
+}

--- a/site/_core/Site.js
+++ b/site/_core/Site.js
@@ -49,7 +49,7 @@ export default ({ page, category, title, section, className, noSearch, children 
             <img className="nav-logo" src="/img/logo.svg" alt="GraphQL Logo" width="30" height="30" />
             GraphQL
           </a>
-          <HeaderLinks section={section} />
+          <HeaderLinks section={section} activeUrl={page.permalink} />
           {noSearch || <Search />}
         </section>
       </header>


### PR DESCRIPTION
## Description
Right now except "code", active status is not shown on the navbar. Therefore, visitors can't see which page there are on.
This fix will show active status on "Learn", "Community", "Code of Conduct".


## Screenshot

### Before the fix

Learn
![Screen Shot 2020-03-25 at 10 55 47 PM](https://user-images.githubusercontent.com/4319619/77550405-0d23ab00-6eec-11ea-8e1c-c2f0b52a2907.png)

Community
![Screen Shot 2020-03-25 at 10 56 21 PM](https://user-images.githubusercontent.com/4319619/77550427-144ab900-6eec-11ea-83b0-8f9f5828e28f.png)

Code of Conduct
![Screen Shot 2020-03-25 at 10 56 32 PM](https://user-images.githubusercontent.com/4319619/77550442-190f6d00-6eec-11ea-9485-ce7bdc2114fb.png)

### After the fix

Learn
![Screen Shot 2020-03-25 at 11 00 03 PM](https://user-images.githubusercontent.com/4319619/77550780-75728c80-6eec-11ea-8221-b79ea96f303a.png)

Community
![Screen Shot 2020-03-25 at 11 00 11 PM](https://user-images.githubusercontent.com/4319619/77550808-7d323100-6eec-11ea-93e9-e139ee4783fe.png)

Code of Conduct
![Screen Shot 2020-03-25 at 11 00 17 PM](https://user-images.githubusercontent.com/4319619/77550884-90450100-6eec-11ea-9c92-16fa954ff075.png)

