### PR TITLE
Adding GraphZahl Swift Library

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -476,6 +476,7 @@ It also provides functionality for the construction of a WebSocket Subscriptions
 ### Swift
 
   - [Graphiti](https://github.com/GraphQLSwift/Graphiti): Swift library for building GraphQL schemas/types fast, safely and easily.
+  - [GraphZahl](https://github.com/nerdsupremacist/GraphZahl): Swift library for writing Declarative, Type-Safe GraphQL APIs with Zero Boilerplate.
 
 ### Python
 


### PR DESCRIPTION
I wrote an alternative to Graphiti that uses reflection to gather all the needed information of the types during runtime...

Here's the library:
https://github.com/nerdsupremacist/GraphZahl

Here's an example of a server using it:
https://github.com/nerdsupremacist/CovidQL