### PR TITLE
Change 'graphql-server' to 'apollo-server'

### DIFF
--- a/site/learn/BestPractice-ServingOverHTTP.md
+++ b/site/learn/BestPractice-ServingOverHTTP.md
@@ -82,4 +82,4 @@ app.use('/graphql', graphqlHTTP({
 ```
 
 ## Node
-If you are using NodeJS, we recommend using either [express-graphql](https://github.com/graphql/express-graphql) or [graphql-server](https://github.com/apollostack/graphql-server).
+If you are using NodeJS, we recommend using either [express-graphql](https://github.com/graphql/express-graphql) or [apollo-server](https://github.com/apollographql/apollo-server).


### PR DESCRIPTION
It seems Apollo has updated the name of the package for their GraphQL server to `apollo-server`. Just wanted to make it more accurate.