### PR TITLE
Add async-graphql rust crate

### DIFF
--- a/src/content/code/code.md
+++ b/src/content/code/code.md
@@ -562,7 +562,25 @@ sleep
 
 ### Rust
 
- - [graphql-rust/juniper](https://github.com/graphql-rust/juniper): GraphQL server library for Rust
+#### [Async-graphql](https://github.com/async-graphql/async-graphql)
+
+ Async-graphql is a high-performance server-side library that supports all GraphQL specifications.
+
+ ```rust
+ use async_graphql::*;
+
+ struct Query;
+
+ #[Object]
+ impl Query {
+    /// Returns the sum of a and b
+    async fn add(&self, a: i32, b: i32) -> i32 {
+        a + b
+    }
+ }
+ ```
+
+#### [graphql-rust/juniper](https://github.com/graphql-rust/juniper): GraphQL server library for Rust
 
 ### Scala
 


### PR DESCRIPTION
`Async-graphql` is a GraphQL server library that fully supports async/await and is easy to use.

Repo: https://github.com/async-graphql/async-graphql
Examples: https://github.com/async-graphql/examples