### PR TITLE
Focus the search bar on "/" keypress

### DIFF
--- a/site/_core/Site.js
+++ b/site/_core/Site.js
@@ -112,5 +112,20 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-44373548-16', 'auto');
 ga('send', 'pageview');
       `}} />
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `(function(){
+              document.addEventListener("keypress", e => {
+                const slashKey = e.key === "/" || e.which === 191 || e.keyCode === 191;
+                if (!slashKey) {
+                  return;
+                }
+                e.preventDefault();
+                const searchInput = document.querySelector('.algolia-search-wrapper input');
+                searchInput.focus();
+              });
+        })()`,
+        }}
+      />
     </body>
   </html>


### PR DESCRIPTION
#### What does this PR do?
This PR adds functionality to the site to focus the search input when a user presses the '/' key

#### Background context
Because the nav bar on the site is not sticky, whenever users need to perform a site-wide search, it would require a scroll back to the top of the site page they are on and then click on the search input before they can type, now, all it takes is pressing the '/' key on the keyboard and it is focused

#### What are relevant issue(s)?
N/A

#### Screenshots
https://www.loom.com/share/71c65b520abc4f09ae61ce22dc8c7a4d

