### PR TITLE
Update Apollo Android to include Kotlin native

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -644,7 +644,7 @@ Executor.execute(schema, query) map println
 
 ### Java / Android
 
-  - [Apollo Android](https://github.com/apollographql/apollo-android): A strongly-typed, caching GraphQL client for Android, written in Java.
+  - [Apollo Android](https://github.com/apollographql/apollo-android): A strongly-typed, caching GraphQL client for the JVM, Android and Kotlin native.
 
   - [Nodes](https://github.com/americanexpress/nodes): A GraphQL JVM Client designed for constructing queries from standard model definitions. By American Express.
 


### PR DESCRIPTION
With [version 2.0](https://github.com/apollographql/apollo-android/releases/tag/v2.0.0), Apollo Android supports generating Kotlin native models.