### PR TITLE
Fix import of "graphqlHTTP" (Tutorial-ExpressGraphQL)

### DIFF
--- a/site/graphql-js/Tutorial-ExpressGraphQL.md
+++ b/site/graphql-js/Tutorial-ExpressGraphQL.md
@@ -17,7 +17,7 @@ Let's modify our “hello world” example so that it's an API server rather tha
 
 ```javascript
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language


### PR DESCRIPTION
Need to use object destructuring here as the "express-graphql" package gives us an object containing property "graphqlHTTP"