### PR TITLE
Fixes syntax error in Express example

### DIFF
--- a/site/code/index.html.js
+++ b/site/code/index.html.js
@@ -275,7 +275,7 @@ Then run \`node server.js\` with this code in \`server.js\`:
 
 \`\`\`js
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 var schema = buildSchema(\`


### PR DESCRIPTION
## What

The docs as they were result in an error in the Express example.

```js
app.use("/graphql", graphqlHTTP({
                    ^

TypeError: graphqlHTTP is not a function
    at Object.<anonymous> (/Users/matt-jarrett/Development/learning-graphql/examples/express.js:14:21)
```

I used ES2015's destructuring to pull out `graphqlHTTP` and the Express example works fine.