### PR TITLE
Fix URL to GitHub public GraphQL API

### DIFF
--- a/site/index.html.js
+++ b/site/index.html.js
@@ -539,7 +539,7 @@ public class Character {
           <img src="/users/logos/twitter.png" title="Twitter" className="round" />
         </a>
         {/**/}
-        <a href="https://developer.github.com/v4/" target="_blank" rel="noopener noreferrer">
+        <a href="https://docs.github.com/en/graphql" target="_blank" rel="noopener noreferrer">
           <img src="/users/logos/github.png" title="GitHub" className="round" />
         </a>
         <a href="https://www.pinterest.com/" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
the original link took users to a page that had a header reading `The content on this site may be out of date. For the most accurate and up-to-date content` and directed them to go to the new link