### PR TITLE
Fix import error in GraphQL.js sample code

### DIFF
--- a/site/graphql-js/Tutorial-BasicTypes.md
+++ b/site/graphql-js/Tutorial-BasicTypes.md
@@ -18,7 +18,7 @@ Each of these types maps straightforwardly to JavaScript, so you can just return
 
 ```javascript
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language


### PR DESCRIPTION
changed graphqlHTTP to { graphqlHTTP }. It was erroring out and doesn't look like it is a default export but a named export from the error I received saying TypeError: graphqlHTTP is not a function