### PR TITLE
Fix "TypeError: graphqlHTTP is not a function" in Passing Arguments page, GraphQL js tutorial

### DIFF
--- a/site/graphql-js/Tutorial-PassingArguments.md
+++ b/site/graphql-js/Tutorial-PassingArguments.md
@@ -58,7 +58,7 @@ The entire code for a server that hosts this `rollDice` API is:
 
 ```javascript
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language


### PR DESCRIPTION
The current example of the rollDice API code contains an error.
```
TypeError: graphqlHTTP is not a function
```

This patch will make it run.