### PR TITLE
Change duplicate body tag to a div

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -6,15 +6,14 @@ import Footer from './Footer'
 import SEO from './Seo'
 
 const Layout = ( { children, title, section, className, noSearch } ) => (
-  // Temporarily added (need to find a way around this)
-  <body className={className}>
+  <div className={className}>
     <SEO title={title} />
     <Header section={section} noSearch={noSearch} />
 
     {children}
 
     <Footer />
-  </body>
+  </div>
 )
 
 Layout.propTypes = {

--- a/src/css/index.less
+++ b/src/css/index.less
@@ -1,7 +1,7 @@
 @import "variables.less";
 
 // Index page uses a fixed header with an overlay
-body.index {
+.index {
   background: #f5f6f8;
   @media screen and (min-width: 1020px) {
     margin-top: 50px;


### PR DESCRIPTION
Resolves

`Fix DOM nesting errors: CSS needs to be modified so that instead of forcing a body tag inside a div components/Layout.js a div with some className is used`

in https://github.com/graphql/graphql.github.io/pull/913#issuecomment-687325610