### PR TITLE
Add Google font imports (Gatsby)

### DIFF
--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -1,3 +1,6 @@
+@import url("https://fonts.googleapis.com/css?family=Rubik:300|Roboto:300");
+@import url("https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i,600");
+
 /* https://www.pantone.com/color-finder/Rhodamine-Red-C */
 @dark-color: #171E26;
 @rhodamine-color: #E10098;


### PR DESCRIPTION
The live website uses a handful of Google fonts. These are also used in the Gatsby site but they are not currently imported, as seen below:

![Group 1 (1)](https://user-images.githubusercontent.com/21051488/95034578-a1759280-0705-11eb-881a-a7bae46ad66e.png)

This PR imports the fonts!