### PR TITLE
Update import statement in "Passing Arguments" from Tutorial-PassingArguments.md 

### DIFF
--- a/site/graphql-js/Tutorial-PassingArguments.md
+++ b/site/graphql-js/Tutorial-PassingArguments.md
@@ -58,7 +58,7 @@ The entire code for a server that hosts this `rollDice` API is:
 
 ```javascript
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language


### PR DESCRIPTION
The import statement for `graphqlHTTP` is incorrect. It throws an error when copied and pasted locally.