### PR TITLE
Correct the Reactiflux discord channel name

### DIFF
--- a/site/community/Community-Resources.md
+++ b/site/community/Community-Resources.md
@@ -37,7 +37,7 @@ Chat with GraphQL developers on IRC at the [freenode](https://freenode.net/) ser
 Many GraphQL developers idle in Discord and Slack chatrooms for live
 communication and quick questions.
 
-Join #graphql on the [ReactiFlux Discord](http://join.reactiflux.com/).
+Join #help-graphql on the [ReactiFlux Discord](http://join.reactiflux.com/).
 
 ### Slack Communities:
 


### PR DESCRIPTION
Reactiflux has changed their graphql channel name from #graphql to #help-graphql