### PR TITLE
Fix graphqlHTTP imports

### DIFF
--- a/site/graphql-js/APIReference-ExpressGraphQL.md
+++ b/site/graphql-js/APIReference-ExpressGraphQL.md
@@ -10,8 +10,8 @@ next: /graphql-js/graphql/
 The `express-graphql` module provides a simple way to create an [Express](https://expressjs.com/) server that runs a GraphQL API.
 
 ```js
-import graphqlHTTP from 'express-graphql'; // ES6
-var graphqlHTTP = require('express-graphql'); // CommonJS
+import { graphqlHTTP } from 'express-graphql'; // ES6
+var { graphqlHTTP } = require('express-graphql'); // CommonJS
 ```
 
 ### graphqlHTTP

--- a/site/graphql-js/Guides-ConstructingTypes.md
+++ b/site/graphql-js/Guides-ConstructingTypes.md
@@ -14,7 +14,7 @@ For example, let's say we are building a simple API that lets you fetch user dat
 
 ```javascript
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 var schema = buildSchema(`
@@ -60,7 +60,7 @@ We can implement this same API without using GraphQL schema language:
 
 ```javascript
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var graphql = require('graphql');
 
 // Maps id to User object

--- a/site/graphql-js/Tutorial-PassingArguments.md
+++ b/site/graphql-js/Tutorial-PassingArguments.md
@@ -58,7 +58,7 @@ The entire code for a server that hosts this `rollDice` API is:
 
 ```javascript
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language


### PR DESCRIPTION
There have been a bunch of PRs related to the lack of curly braces when importing `graphqlHTTP` in code samples - so I went through and fixed the rest of the bugs 🧑‍🚒 