### PR TITLE
Fix placement of copy icon

### DIFF
--- a/src/css/graphql.less
+++ b/src/css/graphql.less
@@ -65,7 +65,6 @@ h3 > .anchor,
 h4 > .anchor,
 h5 > .anchor,
 h6 > .anchor {
-  margin-top: -50px;
   position: absolute;
 }
 


### PR DESCRIPTION
_**Updated note:** This PR may or may not be relevant depending on which Gatsby migration PR we move forward with._

Tiny fix because I noticed it while working on the FAQ page! 

Pay attention to the 🔗  icon ⬇️ 

Before:
![Screen Shot 2020-10-18 at 02 47 48](https://user-images.githubusercontent.com/26869552/96356283-8551f800-10ec-11eb-938e-e3e47aaf76c7.png)

After:
![Screen Shot 2020-10-18 at 02 47 07](https://user-images.githubusercontent.com/26869552/96356287-8aaf4280-10ec-11eb-920a-961cfafc7372.png)
