### PR TITLE
Fix search for gatsby site

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -108,21 +108,6 @@ const Footer = ({sourcePath}: { sourcePath: string }) => {
         </section>
       </footer>
 
-      <script
-        type="text/javascript"
-        src="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"
-      ></script>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
-        docsearch({
-          apiKey: 'd103541f3e6041148aade2e746ed4d61',
-          indexName: 'graphql',
-          inputSelector: '#algolia-search-input'
-        });
-      `,
-        }}
-      />
     </div>
   )
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,10 +3,7 @@ import { Link } from "gatsby"
 import HeaderLinks from "../HeaderLinks"
 import Search from "../Search"
 
-interface Props {
-  noSearch?: boolean
-}
-const Header = ({ noSearch }: Props) => {
+const Header = () => {
   return (
     <header>
       <section>
@@ -20,8 +17,8 @@ const Header = ({ noSearch }: Props) => {
           />
           GraphQL
         </Link>
-        <HeaderLinks section={"home"} />
-        {noSearch || <Search />}
+        <HeaderLinks/>
+        <Search />
       </section>
     </header>
   )

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { Link } from "gatsby"
 
 interface Props {
-  children: React.ReactNode
+  children?: React.ReactNode
   href: string,
   className?:string
 }

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1,10 +1,61 @@
-import React from "react"
+import React, {useEffect} from "react"
 
-const Search = (): JSX.Element => {
+// Added to the global runtime by the script tag further down the file.
+declare const docsearch: any | undefined
+
+
+
+// Runs the new docsearch function over possible search inputs
+const runDocsearchIfPossible = () => {
+    if (typeof docsearch !== 'undefined') {
+      const searches = ["algolia-search-input", "hero-search-input"]
+      for (const searchID of searches) {
+        if (!document.getElementById(searchID)) continue
+
+        docsearch({
+          apiKey: 'd103541f3e6041148aade2e746ed4d61',
+          indexName: 'graphql',
+          inputSelector: `#${searchID}`
+        });
+      }
+    }
+}
+
+const Search = ({searchID}: { searchID?: string}): JSX.Element => {
+  const searchInputID = searchID || "algolia-search-input"
+
+  // This extra bit of mis-direction ensures that non-essential code runs after
+  // the page is loaded
+  useEffect(() => {
+    runDocsearchIfPossible()
+
+    if (document.getElementById("algolia-search")) return
+
+    const searchScript = document.createElement('script');
+    searchScript.id = "algolia-search"
+    const searchCSS = document.createElement('link');
+
+    searchScript.src = "https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js";
+    searchScript.async = true;
+    searchScript.onload = () => {
+      if (typeof docsearch !== 'undefined') {
+        runDocsearchIfPossible()
+
+        searchCSS.rel = 'stylesheet';
+        searchCSS.href = 'https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css'
+        searchCSS.type = 'text/css';
+        document.body.appendChild(searchCSS);
+      }
+    }
+
+    document.body.appendChild(searchScript);
+  }, []);
+
+
   return (
     <div className="algolia-search-wrapper">
       <input
-        id="algolia-search-input"
+        id={searchInputID}
         type="text"
         placeholder="Search docs..."
         aria-label="Search docs"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,7 @@ export default ({ pageContext }) => {
   return (
     <Layout className={"index"} title="GraphQL | A query language for your API" pageContext={pageContext}>
       <section className="fixedSearch">
-        <Search />
+        <Search searchID="hero-search-input" />
       </section>
       <Hero />
       <section className="lead">


### PR DESCRIPTION
Roughly: The previous version of the site would load the page from scratch every time, so calling an external lib at the footer was a reasonable call. Gatsby on the other hand, won't do a full reliable re-render of a page and so when you're interacting with `script` tags etc. There needs to be a bit more dancing to hook stuff up.

This technique is almost C&P'd from the TypeScript website. A different potential fix is to move to the v3 docsearch implementation - https://github.com/microsoft/TypeScript-Website/pull/928, which is done entirely within the bundler context and algolia have done a good job making it work in theses SPA-y sites.

For now this is enough to make it all work right