### PR TITLE
Add Ariadne to Python libraries list

### DIFF
--- a/src/content/code/code.md
+++ b/src/content/code/code.md
@@ -464,6 +464,67 @@ It also provides functionality for the construction of a WebSocket Subscriptions
 
 ### Python
 
+#### [Ariadne](https://ariadnegraphql.org) ([github](https://github.com/mirumee/ariadne))
+
+Ariadne is a Python library for implementing GraphQL servers using schema-first approach. It supports both synchronous and asynchronous query execution, ships with batteries included and simple API that is easy to extend or replace.
+
+Ariadne can be installed with pip:
+
+```bash
+pip install ariadne
+```
+
+It ships with many GraphQL server implementations, enabling easy experimentation:
+
+```python
+from ariadne import ObjectType, QueryType, gql, make_executable_schema
+from ariadne.asgi import GraphQL
+
+# Define types using Schema Definition Language (https://graphql.org/learn/schema/)
+# Wrapping string in gql function provides validation and better error traceback
+type_defs = gql("""
+    type Query {
+        people: [Person!]!
+    }
+    type Person {
+        firstName: String
+        lastName: String
+        age: Int
+        fullName: String
+    }
+""")
+
+# Bind resolver functions to Query fields using QueryType
+query = QueryType()
+
+# Resolvers are simple python functions
+@query.field("people")
+def resolve_people(*_):
+    return [
+        {"firstName": "John", "lastName": "Doe", "age": 21},
+        {"firstName": "Bob", "lastName": "Boberson", "age": 24},
+    ]
+
+# Bind resolver functions to custom type fields using ObjectType
+person = ObjectType("Person")
+@person.field("fullName")
+def resolve_person_fullname(person, *_):
+    return "%s %s" % (person["firstName"], person["lastName"])
+
+# Create executable GraphQL schema
+schema = make_executable_schema(type_defs, query, person)
+
+# Create an ASGI app using the schema, running in debug mode
+app = GraphQL(schema, debug=True)
+```
+
+Above server can be ran with uvicorn:
+
+```
+pip install uvicorn
+uvicorn example:app
+```
+
 #### [Graphene](http://graphene-python.org/) ([github](https://github.com/graphql-python/graphene))
 
 A Python library for building GraphQL APIs.

--- a/src/content/code/code.md
+++ b/src/content/code/code.md
@@ -466,7 +466,7 @@ It also provides functionality for the construction of a WebSocket Subscriptions
 
 #### [Ariadne](https://ariadnegraphql.org) ([github](https://github.com/mirumee/ariadne))
 
-Ariadne is a Python library for implementing GraphQL servers using schema-first approach. It supports both synchronous and asynchronous query execution, ships with batteries included and simple API that is easy to extend or replace.
+Ariadne is a Python library for implementing GraphQL servers using schema-first approach. It supports both synchronous and asynchronous query execution, ships with batteries included for common GraphQL server problems like query cost validation or performance tracing and has simple API that is easy to extend or replace.
 
 Ariadne can be installed with pip:
 
@@ -484,35 +484,20 @@ from ariadne.asgi import GraphQL
 # Wrapping string in gql function provides validation and better error traceback
 type_defs = gql("""
     type Query {
-        people: [Person!]!
-    }
-    type Person {
-        firstName: String
-        lastName: String
-        age: Int
-        fullName: String
+        hello: String!
     }
 """)
 
-# Bind resolver functions to Query fields using QueryType
-query = QueryType()
+# Bind resolver functions to Query's fields using QueryType
+query_type = QueryType()
 
 # Resolvers are simple python functions
-@query.field("people")
-def resolve_people(*_):
-    return [
-        {"firstName": "John", "lastName": "Doe", "age": 21},
-        {"firstName": "Bob", "lastName": "Boberson", "age": 24},
-    ]
-
-# Bind resolver functions to custom type fields using ObjectType
-person = ObjectType("Person")
-@person.field("fullName")
-def resolve_person_fullname(person, *_):
-    return "%s %s" % (person["firstName"], person["lastName"])
+@query_type.field("hello")
+def resolve_hello(*_):
+    return "Hello world!"
 
 # Create executable GraphQL schema
-schema = make_executable_schema(type_defs, query, person)
+schema = make_executable_schema(type_defs, query_type)
 
 # Create an ASGI app using the schema, running in debug mode
 app = GraphQL(schema, debug=True)


### PR DESCRIPTION
**[Ariadne](https://github.com/mirumee/ariadne/)**

Ariadne is Python library for implementing GraphQL servers:

- It's schema first
- Written for Python 3.7+
- Batteries included: Async, ASGI, WSGI, Django, Flask, Starlette
- [It has extensive documentation rich in examples and guides](https://ariadnegraphql.org/)