### PR TITLE
make sticky side menu items

### DIFF
--- a/src/assets/css/_css/docs.less
+++ b/src/assets/css/_css/docs.less
@@ -248,6 +248,10 @@
   margin: 1em 0 4em;
   width: 195px;
   padding-left: 20px;
+  position: -webkit-sticky;
+    position: sticky;
+    top: 24px;
+    height: 100%;
 
   @media screen and (max-width: 740px) {
     width: auto;


### PR DESCRIPTION
#### What does this PR do?
This PR adds styles to make the sidebar menu sticky on desktop screens

#### Background context
The sidenav keeps scrolling with the page and makes it difficult when users need to navigate forcing them to scroll back up before they can navigate

#### What are relevant issue(s)?
#558 

#### Screenshots
![Annotation 2020-005-09 215804](https://user-images.githubusercontent.com/12516195/81484774-4fa50b00-9240-11ea-8a69-3ff1a131e6ba.png)

![Annotation 2020-05-09 215804](https://user-images.githubusercontent.com/12516195/81484779-559aec00-9240-11ea-913e-50bbd4c7a508.png)

