### PR TITLE
Set min-height on header to fix responsiveness

### DIFF
--- a/src/assets/css/_css/graphql.less
+++ b/src/assets/css/_css/graphql.less
@@ -119,7 +119,7 @@ p code {
 
 header {
   .headline-font(@size: 15px);
-  height: 50px;
+  min-height: 50px;
   background: white;
   box-shadow: inset 0 -1px 0 0px rgba(0, 0, 0, 0.1);
   z-index: 10;


### PR DESCRIPTION
A tiny CSS tweak to make the header more responsive on smaller breakpoints! 

_Before:_
![Screen Shot 2020-11-13 at 16 15 21](https://user-images.githubusercontent.com/26869552/99092572-98fc5b80-25d1-11eb-99f4-812fd7011ff5.png)

_After:_
![Screen Shot 2020-11-13 at 16 54 09](https://user-images.githubusercontent.com/26869552/99092581-9f8ad300-25d1-11eb-8484-b4f1a7897f38.png)

In the future, it could be nice to implement a burger menu. That way, the search functionality would also be available. 
