### PR TITLE
update documentation on graphql-kotlin

### DIFF
--- a/src/content/code/language-support/java-kotlin-android/client/graphql-kotlin.md
+++ b/src/content/code/language-support/java-kotlin-android/client/graphql-kotlin.md
@@ -1,0 +1,88 @@
+---
+name: graphql-kotlin
+description: A set of libraries for running GraphQL client and server in Kotlin.
+url: https://github.com/ExpediaGroup/graphql-kotlin/
+github: ExpediaGroup/graphql-kotlin
+---
+
+GraphQL Kotlin provides a set of lightweight type-safe GraphQL HTTP clients. The library provides Ktor HTTP client and Spring WebClient based reference implementations as well as allows for custom implementations using other engines. Type-safe data models are generated at build time by the GraphQL Kotlin Gradle and Maven plugins.
+
+To generate Ktor based GraphQL client add following to your Gradle build file:
+
+```kotlin
+// build.gradle.kts
+import com.expediagroup.graphql.plugin.generator.GraphQLClientType
+import com.expediagroup.graphql.plugin.gradle.graphql
+
+plugins {
+    id("com.expediagroup.graphql") version $latestGraphQLKotlinVersion
+}
+
+dependencies {
+  implementation("com.expediagroup:graphql-kotlin-ktor-client:$latestGraphQLKotlinVersion")
+}
+
+graphql {
+    client {
+        // target GraphQL endpoint
+        endpoint = "http://localhost:8080/graphql"
+        // package for generated client code
+        packageName = "com.example.generated"
+        clientType = GraphQLClientType.KTOR
+    }
+}
+```
+
+By default, GraphQL Kotlin plugin will look for query files under `src/main/resources`. Given `helloWorld: String!` query we can add following `HelloWorldQuery.graphql` sample query to our repo:
+
+```graphql
+query HelloWorldQuery {
+  helloWorld
+}
+```
+
+Plugin will generate following client code:
+
+```kotlin
+package com.example.generated
+
+import com.expediagroup.graphql.client.GraphQLKtorClient
+import com.expediagroup.graphql.types.GraphQLResponse
+import kotlin.String
+
+const val HELLO_WORLD_QUERY: String = "query HelloWorldQuery {\n    helloWorld\n}"
+
+class HelloWorldQuery(
+  private val graphQLClient: GraphQLKtorClient<*>
+) {
+  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}): GraphQLResponse<HelloWorldQuery.Result> =
+      graphQLClient.execute(HELLO_WORLD_QUERY, "HelloWorldQuery", null, requestBuilder)
+
+  data class Result(
+    val helloWorld: String
+  )
+}
+```
+
+We can then execute the client 
+
+```kotlin
+package com.example.client
+
+import com.expediagroup.graphql.client.GraphQLKtorClient
+import com.expediagroup.graphql.generated.HelloWorldQuery
+import kotlinx.coroutines.runBlocking
+import java.net.URL
+
+fun main() {
+    val client = GraphQLKtorClient(url = URL("http://localhost:8080/graphql"))
+    val helloWorldQuery = HelloWorldQuery(client)
+    runBlocking {
+        val result = helloWorldQuery.execute()
+        println("hello world query result: ${result.data?.helloWorld}")
+    }
+    client.close()
+}
+```
+
+See [graphql-kotlin docs](https://expediagroup.github.io/graphql-kotlin/docs/getting-started) for additial details.

--- a/src/content/code/language-support/java-kotlin-android/server/graphql-kotlin.md
+++ b/src/content/code/language-support/java-kotlin-android/server/graphql-kotlin.md
@@ -1,8 +1,40 @@
 ---
 name: graphql-kotlin
-description: A set of libraries for running GraphQL server in Kotlin.
+description: A set of libraries for running GraphQL client and server in Kotlin.
 url: https://github.com/ExpediaGroup/graphql-kotlin/
 github: ExpediaGroup/graphql-kotlin
 ---
 
+GraphQL Kotlin follows a code first approach for generating your GraphQL schemas. Given the similarities between Kotlin and GraphQL, such as the ability to define nullable/non-nullable types, a schema can be generated from Kotlin code without any separate schema specification. To create a reactive GraphQL web server add following dependency to your Gradle build file:
 
+```kotlin
+// build.gradle.kts
+implementation("com.expediagroup", "graphql-kotlin-spring-server", latestVersion)
+```
+
+We also need to provide a list of supported packages that can be scanned for exposing your schema objects through reflections. Add following configuration to your `application.yml` file:
+
+```yaml
+graphql:
+  packages:
+    - "com.your.package"
+```
+
+With the above configuration we can now create our schema. In order to expose your queries, mutations and/or subscriptions in the GraphQL schema you simply need to implement corresponding marker interface and they will be automatically picked up by `graphql-kotlin-spring-server` auto-configuration library.
+
+```kotlin
+@Component
+class HelloWorldQuery : Query {
+  fun helloWorld() = "Hello World!!!"
+}
+```
+
+This will result in a reactive GraphQL web application with following schema:
+
+```graphql
+type Query {
+  helloWorld: String!
+}
+```
+
+See [graphql-kotlin docs](https://expediagroup.github.io/graphql-kotlin/docs/getting-started) for additial details.


### PR DESCRIPTION
Add documentation on `graphql-kotlin` (https://github.com/ExpediaGroup/graphql-kotlin) usage for creating reactive GraphQL server and http client.