### PR TITLE
Include code of conduct directory in create page process

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -172,7 +172,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
       if (
         sourceInstanceName !== "content" ||
-        relativeDirectory.includes("code")
+        relativeDirectory.includes("code/")
       ) {
         return
       }


### PR DESCRIPTION
The code of conduct page is currently being caught by:

https://github.com/graphql/graphql.github.io/blob/2e4c1eb5faa4c9884f173442ab55d3370def1289/gatsby-node.js#L175-L178

Resolves https://github.com/graphql/graphql.github.io/issues/966