### PR TITLE
Add CSS transitions for revealing FAQ answers

### DIFF
--- a/src/assets/css/_css/faq.less
+++ b/src/assets/css/_css/faq.less
@@ -68,13 +68,15 @@
     opacity: 0;
     margin-bottom: 0;
     margin-top: 0;
-    display: none;
+    overflow: hidden;
+    transition: height 0ms 400ms, opacity 400ms 0ms;
 
     &.show {
       opacity: 1;
       max-height: 800px;
       margin-bottom: 1.0875rem;
-      display: block;
+      overflow: visible;
+      transition: height 0ms 0ms, opacity 600ms 0ms;
     }
   }
 
@@ -82,13 +84,14 @@
     max-height: 0;
     opacity: 0;
     margin: 0;
-    display: none;
+    overflow: hidden;
+    transition: height 0ms 400ms, opacity 400ms 0ms;
 
     &.show {
       opacity: 1;
       max-height: 400px;
       margin-bottom: 1.0875rem;
-      display: block;
+      transition: height 0ms 0ms, opacity 600ms 0ms;
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/graphql/graphql.github.io/issues/995

## Description

Transition doesn't work on `display` so I'm relying on overflow instead. Feel free to adjust the values for a shorter/longer transition!


https://user-images.githubusercontent.com/21051488/103600440-22396a00-4f53-11eb-9c3f-c32f8692ccc5.mov



