### PR TITLE
Fix search bar issues

### DIFF
--- a/src/Containers/Sections/Hero/index.tsx
+++ b/src/Containers/Sections/Hero/index.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'gatsby';
 import React from 'react';
 import HeaderLinks from '../../../components/HeaderLinks';
+import Search from '../../../components/Search';
 import Prism from '../../../components/Prism';
 
   
@@ -11,6 +12,7 @@ const Hero = () => {
           <header aria-hidden>
             <section>
               <HeaderLinks />
+              <Search searchID="hero-search-input" />
             </section>
           </header>
           <section className="intro">

--- a/src/assets/css/_css/algolia.less
+++ b/src/assets/css/_css/algolia.less
@@ -23,11 +23,21 @@
     margin-top: 10px;
     outline: none;
     padding: 0 10px 0 35px;
-    width: 180px;
+    width: 160px;
     transition: width 0.2s ease-out;
 
-    &:focus {
-      width: 250px;
+    @media screen and (min-width: 1076px) {
+      &:focus {
+        width: 190px;
+      }
+    }
+    @media screen and (min-width: 1065px) and (max-width: 1075px) {
+      &:focus {
+        width: 180px;
+      }
+    }
+    @media screen and (min-width: 1021px) and (max-width: 1064px) {
+      width: 135px;
     }
   }
 

--- a/src/assets/css/_css/index.less
+++ b/src/assets/css/_css/index.less
@@ -18,14 +18,6 @@ div.index {
     }
   }
 
-  .fixedSearch {
-    position: fixed;
-    right: 0;
-    left: 0;
-    z-index: 12;
-    pointer-events: none;
-  }
-
   .hero {
     background: @dark-color;
     @media screen and (min-width: 1020px) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,6 @@
 import React from "react"
 import Layout from "../components/Layout"
 
-import Search from "../components/Search"
-
 import Hero from "../Containers/Sections/Hero"
 import SingleRequest from "../Containers/Sections/SingleRequest"
 import TypeSystem from "../Containers/Sections/TypeSystem"
@@ -15,9 +13,6 @@ import WhosUsing from "../Containers/Sections/WhosUsing"
 export default ({ pageContext }) => {
   return (
     <Layout className={"index"} title="GraphQL | A query language for your API" pageContext={pageContext}>
-      <section className="fixedSearch">
-        <Search searchID="hero-search-input" />
-      </section>
       <Hero />
       <section className="lead">
         <h1>A query language for your API</h1>


### PR DESCRIPTION
<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #1006 and #831 

## Description

This PR fixes the overlap issue of search bar in all the screens. 
- Uses media queries to ensure that the search bar is always inside the navbar and never pops out
- Moves the search bar from `src/pages/index.ts` to `Container/Sections/Hero/index.ts` thereby ensuring multiple search bars do not overlap

## Screenshots
- 1021 to 1064px
![Screenshot 2021-02-20 at 12 53 38 PM](https://user-images.githubusercontent.com/51132453/108587617-b7b18180-737a-11eb-8372-3f0f8d67c35e.png)
- 1065 to 1075px
![Screenshot 2021-02-20 at 12 53 09 PM](https://user-images.githubusercontent.com/51132453/108587618-b97b4500-737a-11eb-9c66-27c26ac887ec.png)
- Greater than 1075px
![Screenshot 2021-02-20 at 12 52 28 PM](https://user-images.githubusercontent.com/51132453/108587620-baac7200-737a-11eb-9ad9-3c46a1dd97b5.png)
(For less than 1021px search bar is hidden)