### PR TITLE
Add GiraphQL schema builder to list of javascript libraries

### DIFF
--- a/src/content/code/language-support/javascript/tools/giraphql.md
+++ b/src/content/code/language-support/javascript/tools/giraphql.md
@@ -1,0 +1,32 @@
+---
+name: GiraphQL
+description: A plugin based schema builder for creating code-first GraphQL schemas in typescript
+url: https://giraphql.com/
+github: hayes/giraphql
+npm: "@giraphql/core"
+---
+
+GiraphQL makes writing type-safe schemas simple, and works without a code generator,
+build process, or extensive manual type definitions.
+
+```ts
+import { ApolloServer } from "apollo-server"
+import SchemaBuilder from "@giraphql/core"
+
+const builder = new SchemaBuilder({})
+
+builder.queryType({
+  fields: t => ({
+    hello: t.string({
+      args: {
+        name: t.arg.string({}),
+      },
+      resolve: (parent, { name }) => `hello, ${name || "World"}`,
+    }),
+  }),
+})
+
+new ApolloServer({
+  schema: builder.toSchema({}),
+}).listen(3000)
+```


### PR DESCRIPTION
## Description

Adds [GiraphQL](https://giraphql.com) to the list of javascript tools.
