### PR TITLE
Add DEV Community link

### DIFF
--- a/notes/NewSiteArchitecture.md
+++ b/notes/NewSiteArchitecture.md
@@ -159,6 +159,7 @@ This page should serve as a high-level view of what resources are available and 
 
 * Links out to:
   * Stack Overflow topic
+  * DEV Community tag
   * Slack/Discord channels
   * Popular blogs
   * Twitter feed

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -43,6 +43,10 @@ const getLinks = (sourcePath: string): FooterLinks[] => [
         href: "http://stackoverflow.com/questions/tagged/graphql",
       },
       {
+        text: "DEV Community",
+        href: "https://dev.to/t/graphql",
+      },
+      {
         text: "Facebook Group",
         href: "https://www.facebook.com/groups/graphql.community/",
       },

--- a/src/content/community/Community-Resources.md
+++ b/src/content/community/Community-Resources.md
@@ -11,6 +11,10 @@ sublinks: Blogs,Videos,Books,More Resources
 
 Many members of the community use Stack Overflow to ask and answer questions. [Read through the existing questions tagged with **graphql** or ask your own!](http://stackoverflow.com/questions/tagged/graphql)
 
+## DEV Community
+
+Members of the community write blog posts and hold discussions on the [DEV GraphQL tag](https://dev.to/t/graphql).
+
 ## Facebook Group
 
 Join the [GraphQL Facebook Group](https://www.facebook.com/groups/graphql.community/) sharing and discovering new content. The GraphQL Facebook group is the preferred venue for announcements and broader discussion.


### PR DESCRIPTION
## Description

This adds a link to https://dev.to/t/graphql.

This follows the pattern used on project sites such as [reactjs.org](https://reactjs.org/) and [reactnative.dev](https://reactnative.dev/) where a `DEV Community` link to the appropriate site tag is included in the site footer alongside Stack Overflow, etc. The resource is also added to the `Community` and acts as an evergreen link to the newest GraphQL discussions happening on DEV.

`#graphql` is the official supported tag on DEV. It is actively moderated by the community, and folks from this project are more than welcome to get involved in that process by contacting yo@dev.to.

Longtime fan of GraphQL, keep up the great work y'all.