### PR TITLE
Azkron .inner-content max-width:740px is too narrow and many code examples are not fully visible

### DIFF
--- a/src/assets/css/_css/docs.less
+++ b/src/assets/css/_css/docs.less
@@ -134,7 +134,7 @@
 
 .inner-content {
   flex: 1;
-  max-width: 720px;
+  
   @media screen and (max-width: 740px) {
     margin-right: 0;
   }


### PR DESCRIPTION
…re not fully visible so I just removed it

<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #<issue number>

## Description

<!-- Write a brief description of the changes introduced by this PR -->