### PR TITLE
Fix specs URL.

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -54,7 +54,7 @@ const getLinks = (sourcePath: string): FooterLinks[] => [
     subsections: [
       {
         text: "GraphQL Specification",
-        href: "https://graphql.github.io/graphql-spec/",
+        href: "https://spec.graphql.org/",
       },
       { text: "GraphQL Foundation", href: "https://foundation.graphql.org/" },
       {

--- a/src/components/HeaderLinks/index.tsx
+++ b/src/components/HeaderLinks/index.tsx
@@ -15,7 +15,7 @@ const links: LinkItem[] = [
   {
     section: "spec",
     text: "Spec",
-    href: "https://graphql.github.io/graphql-spec/",
+    href: "https://spec.graphql.org/",
   },
   {
     section: "codeofconduct",


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->



Right now the 2 spec links point to `https://graphql.github.io/graphql-spec/` that redirects to `http://spec.graphql.org/` (insecure).

This PR fixes that and points directly to  `https://spec.graphql.org/` (secure).

