### PR TITLE
Server GraphQL structure does not match the Query

### DIFF
--- a/src/content/learn/Learn-Schema.md
+++ b/src/content/learn/Learn-Schema.md
@@ -101,7 +101,7 @@ That means that the GraphQL service needs to have a `Query` type with `hero` and
 
 ```graphql
 type Query {
-  hero(episode: Episode): Character
+  hero: Character
   droid(id: ID!): Droid
 }
 ```


### PR DESCRIPTION
Currently learning GraphQL and noticed an inconsistency in between:
```graphql
type Query {
  hero: Character
  droid(id: ID!): Droid
}
```
and 
```
query {
  hero {
    name
  }
  droid(id: "2000") {
    name
  }
}
```

<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #<issue number>

## Description

<!-- Write a brief description of the changes introduced by this PR -->