### PR TITLE
Fix .js -> .ts links after TypeScript conversion

### DIFF
--- a/src/content/learn/Learn-Introspection.md
+++ b/src/content/learn/Learn-Introspection.md
@@ -11,7 +11,7 @@ queries it supports. GraphQL allows us to do so using the introspection
 system!
 
 For our Star Wars example, the file
-[starWarsIntrospection-test.js](https://github.com/graphql/graphql-js/blob/main/src/__tests__/starWarsIntrospection-test.js)
+[starWarsIntrospection-test.ts](https://github.com/graphql/graphql-js/blob/main/src/__tests__/starWarsIntrospection-test.ts)
 contains a number of queries demonstrating the introspection system, and is a
 test file that can be run to exercise the reference implementation's
 introspection system.
@@ -180,6 +180,6 @@ and create documentation browsers, or rich IDE experiences.
 This has just scratched the surface of the introspection system; we can
 query for enum values, what interfaces a type implements, and more. We
 can even introspect on the introspection system itself. The specification goes
-into more detail about this topic in the "Introspection" section, and the [introspection](https://github.com/graphql/graphql-js/blob/main/src/type/introspection.js)
+into more detail about this topic in the "Introspection" section, and the [introspection](https://github.com/graphql/graphql-js/blob/main/src/type/introspection.ts)
 file in GraphQL.js contains code implementing a specification-compliant GraphQL
 query introspection system.

--- a/src/content/learn/Learn-Validation.md
+++ b/src/content/learn/Learn-Validation.md
@@ -12,7 +12,7 @@ developers when an invalid query has been created, without having to rely
 on runtime checks.
 
 For our Star Wars example, the file
-[starWarsValidation-test.js](https://github.com/graphql/graphql-js/blob/main/src/__tests__/starWarsValidation-test.js)
+[starWarsValidation-test.ts](https://github.com/graphql/graphql-js/blob/main/src/__tests__/starWarsValidation-test.ts)
 contains a number of queries demonstrating various invalidities, and is a test
 file that can be run to exercise the reference implementation's validator.
 


### PR DESCRIPTION
Some of the examples in /learn linked directly to .js files in GraphQL.js that have since been
converted to .ts files.

Closes #1055 

Thanks @aghArdeshir!

Signed-off-by: Brian Warner <brian@bdwarner.com>

<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #<issue number>

## Description

<!-- Write a brief description of the changes introduced by this PR -->