### PR TITLE
Add `@deprecated` and `@specifiedBy` to docs

### DIFF
--- a/src/content/learn/Learn-Queries.md
+++ b/src/content/learn/Learn-Queries.md
@@ -256,10 +256,12 @@ query Hero($episode: Episode, $withFriends: Boolean!) {
 
 Try editing the variables above to instead pass `true` for `withFriends`, and see how the result changes.
 
-We needed to use a new feature in GraphQL called a _directive_. A directive can be attached to a field or fragment inclusion, and can affect execution of the query in any way the server desires. The core GraphQL specification includes exactly two directives, which must be supported by any spec-compliant GraphQL server implementation:
+We needed to use a new feature in GraphQL called a _directive_. A directive can be attached to a field or fragment inclusion, and can affect execution of the query in any way the server desires. The core GraphQL specification includes exactly four directives, which must be supported by any spec-compliant GraphQL server implementation:
 
 - `@include(if: Boolean)` Only include this field in the result if the argument is `true`.
 - `@skip(if: Boolean)` Skip this field if the argument is `true`.
+- `@deprecated(reason: String = "No longer supported")` Indicate deprecated portions of a GraphQL service’s schema.
+- `@specifiedBy(url: String!)` Provide a scalar specification URL to specify the behavior of [custom scalar types](http://spec.graphql.org/draft/#sec-Scalars.Custom-Scalars). 
 
 Directives can be useful to get out of situations where you otherwise would need to do string manipulation to add and remove fields in your query. Server implementations may also add experimental features by defining completely new directives.
 


### PR DESCRIPTION
## Description

Directives section of the learn docs only include the `@skip` and `@include` directives. However, the spec also defines [`@deprecated`](http://spec.graphql.org/draft/#sec--deprecated) and [`@specifiedBy`](http://spec.graphql.org/draft/#sec--specifiedBy):

- `@deprecated(reason: String = "No longer supported")` Indicate deprecated portions of a GraphQL service’s schema.
- `@specifiedBy(url: String!)` Provide a scalar specification URL to specify the behavior of [custom scalar types](http://spec.graphql.org/draft/#sec-Scalars.Custom-Scalars).

I've found most beginner level educational material for GraphQL tends to avoid directives, so the more information we can provide here without just porting the spec over the better. It may also be useful to include links to work in progress directives like [@defer and @stream](https://github.com/graphql/graphql-spec/blob/main/rfcs/DeferStream.md)