### PR TITLE
docs: update sangria url

### DIFF
--- a/src/content/code/language-support/scala/server/sangria.md
+++ b/src/content/code/language-support/scala/server/sangria.md
@@ -1,7 +1,7 @@
 ---
 name: Sangria
 description: A Scala GraphQL library that supports [Relay](https://facebook.github.io/relay/).
-url: http://sangria-graphql.org/
+url: https://sangria-graphql.github.io/
 github: sangria-graphql/sangria
 ---
 


### PR DESCRIPTION
Updates the Sangria URL from `http://sangria-graphql.org/` to `https://sangria-graphql.github.io/` since the Sangria website no longer appears to be hosted at `http://sangria-graphql.org/`