### PR TITLE
Update Sangira URL

### DIFF
--- a/src/content/code/language-support/scala/server/sangria.md
+++ b/src/content/code/language-support/scala/server/sangria.md
@@ -1,7 +1,7 @@
 ---
 name: Sangria
 description: A Scala GraphQL library that supports [Relay](https://facebook.github.io/relay/).
-url: http://sangria-graphql.org/
+url: https://sangria-graphql.github.io/
 github: sangria-graphql/sangria
 ---
 


### PR DESCRIPTION
Update URL for Sangria. Thanks to https://github.com/graphql/graphql.github.io/pull/1067