### PR TITLE
Replace LICENSE with standard MIT/GraphQL Contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,26 +1,21 @@
-LICENSE AGREEMENT For graphql.org software
+MIT License
 
-Facebook, Inc. (“Facebook”) owns all right, title and interest, including all
-intellectual property and other proprietary rights, in and to the graphql.org
-software. Subject to your compliance with these terms, you are hereby granted a
-non-exclusive, worldwide, royalty-free copyright license to (1) use and copy the
-graphql.org software; and (2) reproduce and distribute the graphql.org software
-as part of your own software (“Your Software”). Facebook reserves all rights not
-expressly granted to you in this license agreement.
+Copyright (c) GraphQL Contributors
 
-THE SOFTWARE AND DOCUMENTATION, IF ANY, ARE PROVIDED "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES (INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE) ARE DISCLAIMED. IN NO
-EVENT SHALL FACEBOOK OR ITS AFFILIATES, OFFICES, DIRECTORS OR EMPLOYEES BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THE SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-You will include in Your Software (e.g., in the file(s), documentation or other
-materials accompanying your software): (1) the disclaimer set forth above; (2)
-this sentence; and (3) the following copyright notice:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Copyright (c) 2015, Facebook, Inc. All rights reserved.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
See https://github.com/graphql/graphql-wg/issues/662 for context.

This is a very focused change. Note that there are still a few code files which are "Copyright Facebook". I personally wrote those original files and haven't bothered changing them. (See why: https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/)

However future code and usage is governed by our LICENSE file, which we standardize as MIT including a general "Copyright (c) GraphQL Contributors". Same as our other repositories
