### PR TITLE
Fix incorrect query on Queries and Mutation

### DIFF
--- a/src/content/learn/Learn-Queries.md
+++ b/src/content/learn/Learn-Queries.md
@@ -130,7 +130,7 @@ It is possible for fragments to access variables declared in the query or mutati
 
 ```graphql
 # { "graphiql": true }
-query HeroComparison($first: Int = 3) {
+query HeroComparison {
   leftComparison: hero(episode: EMPIRE) {
     ...comparisonFields
   }
@@ -141,13 +141,8 @@ query HeroComparison($first: Int = 3) {
 
 fragment comparisonFields on Character {
   name
-  friendsConnection(first: $first) {
-    totalCount
-    edges {
-      node {
-        name
-      }
-    }
+  friends {
+    name
   }
 }
 ```


### PR DESCRIPTION
Closes #1126

## Description

One of the queries here uses "friendsConnection", but the rest use "friends", and only friends is valid in this schema.

This replaces the incorrect usage.

Note that I'm not sure how to test the Graphiql portion of this change — the only validation I did was that the query looks correct now.