### PR TITLE
fix: getting started tutorial example

### DIFF
--- a/site/graphql-js/Tutorial-GettingStarted.md
+++ b/site/graphql-js/Tutorial-GettingStarted.md
@@ -23,7 +23,7 @@ npm install graphql --save
 To handle GraphQL queries, we need a schema that defines the `Query` type, and we need an API root with a function called a “resolver” for each API endpoint. For an API that just returns “Hello world!”, we can put this code in a file named `server.js`:
 
 ```javascript
-var { graphql, buildSchema } = require("graphql");
+var { graphql, buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language
 var schema = buildSchema(`
@@ -35,7 +35,7 @@ var schema = buildSchema(`
 // The root provides a resolver function for each API endpoint
 var rootValue = {
   hello: () => {
-    return "Hello world!";
+    return 'Hello world!';
   },
 };
 
@@ -54,11 +54,7 @@ node server.js
 You should see the GraphQL response printed out:
 
 ```javascript
-{
-  data: {
-    hello: "Hello world!";
-  }
-}
+{ data: { hello: 'Hello world!' } }
 ```
 
 Congratulations - you just executed a GraphQL query!

--- a/site/graphql-js/Tutorial-GettingStarted.md
+++ b/site/graphql-js/Tutorial-GettingStarted.md
@@ -40,7 +40,7 @@ var rootValue = {
 };
 
 // Run the GraphQL query '{ hello }' and print out the response
-graphql({ schema, source: "{ hello }", rootValue }).then((response) => {
+graphql({ schema, source: '{ hello }', rootValue }).then((response) => {
   console.log(response);
 });
 ```

--- a/site/graphql-js/Tutorial-GettingStarted.md
+++ b/site/graphql-js/Tutorial-GettingStarted.md
@@ -23,7 +23,7 @@ npm install graphql --save
 To handle GraphQL queries, we need a schema that defines the `Query` type, and we need an API root with a function called a “resolver” for each API endpoint. For an API that just returns “Hello world!”, we can put this code in a file named `server.js`:
 
 ```javascript
-var { graphql, buildSchema } = require('graphql');
+var { graphql, buildSchema } = require("graphql");
 
 // Construct a schema, using GraphQL schema language
 var schema = buildSchema(`
@@ -33,14 +33,14 @@ var schema = buildSchema(`
 `);
 
 // The root provides a resolver function for each API endpoint
-var root = {
+var rootValue = {
   hello: () => {
-    return 'Hello world!';
+    return "Hello world!";
   },
 };
 
 // Run the GraphQL query '{ hello }' and print out the response
-graphql(schema, '{ hello }', root).then((response) => {
+graphql({ schema, source: "{ hello }", rootValue }).then((response) => {
   console.log(response);
 });
 ```
@@ -54,7 +54,11 @@ node server.js
 You should see the GraphQL response printed out:
 
 ```javascript
-{ data: { hello: 'Hello world!' } }
+{
+  data: {
+    hello: "Hello world!";
+  }
+}
 ```
 
 Congratulations - you just executed a GraphQL query!


### PR DESCRIPTION
Closes #1168

## Description

Uses the correct args format (graphql@16) for the getting started tutorial.