### PR TITLE
Get friendConnection queries working

### DIFF
--- a/src/components/Marked/swapiSchema.tsx
+++ b/src/components/Marked/swapiSchema.tsx
@@ -7,6 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { Buffer } from 'buffer';
+
 import {
   GraphQLSchema,
   GraphQLObjectType,


### PR DESCRIPTION
<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #1126, closes #1074.

## Description

Queries involving the `friendsConnection` field were failing (see e.g. #1126 for error). I think this was due to `Buffer` not being imported in the server source. With this change, I can get the examples in both sections ([fragments](https://graphql.org/learn/queries/#fragments) and [pagination](https://graphql.org/learn/pagination/#complete-connection-model)) working locally.