### PR TITLE
update to use object with graphql() vs 3 params

### DIFF
--- a/src/content/graphql-js/Tutorial-GettingStarted.md
+++ b/src/content/graphql-js/Tutorial-GettingStarted.md
@@ -33,14 +33,18 @@ var schema = buildSchema(`
 `);
 
 // The root provides a resolver function for each API endpoint
-var root = {
+var rootValue = {
   hello: () => {
     return 'Hello world!';
   },
 };
 
 // Run the GraphQL query '{ hello }' and print out the response
-graphql(schema, '{ hello }', root).then((response) => {
+graphql({
+  schema,
+  source: '{ hello }',
+  rootValue
+}).then((response) => {
   console.log(response);
 });
 ```

--- a/src/content/graphql-js/Tutorial-GettingStarted.md
+++ b/src/content/graphql-js/Tutorial-GettingStarted.md
@@ -32,7 +32,7 @@ var schema = buildSchema(`
   }
 `);
 
-// The root provides a resolver function for each API endpoint
+// The rootValue provides a resolver function for each API endpoint
 var rootValue = {
   hello: () => {
     return 'Hello world!';


### PR DESCRIPTION
<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #<issue number>

## Description

Small update to the NodeJS GraphQL docs to use an object with the graphql() function rather than three parameters.