### PR TITLE
rename input type identifier in example on Learn-Schema page

### DIFF
--- a/src/content/learn/Learn-Schema.md
+++ b/src/content/learn/Learn-Schema.md
@@ -360,7 +360,7 @@ Note that `name` is still specified on `Starship` because otherwise it wouldn't 
 So far, we've only talked about passing scalar values, like enums or strings, as arguments into a field. But you can also easily pass complex objects. This is particularly valuable in the case of mutations, where you might want to pass in a whole object to be created. In the GraphQL schema language, input types look exactly the same as regular object types, but with the keyword `input` instead of `type`:
 
 ```graphql
-input ReviewInput {
+input Review {
   stars: Int!
   commentary: String
 }
@@ -370,7 +370,7 @@ Here is how you could use the input object type in a mutation:
 
 ```graphql
 # { "graphiql": true, "variables": { "ep": "JEDI", "review": { "stars": 5, "commentary": "This is a great movie!" } } }
-mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {
+mutation CreateReviewForEpisode($ep: Episode!, $review: Review!) {
   createReview(episode: $ep, review: $review) {
     stars
     commentary


### PR DESCRIPTION
## Description

Rename input type `ReviewInput` to `Review` to align the identifier with
the style used elsewhere (no Hungarian notation).
