### PR TITLE
Adding ELI5 video to the list of GraphQL videos

### DIFF
--- a/src/content/community/Community-Users.md
+++ b/src/content/community/Community-Users.md
@@ -109,6 +109,7 @@ Developers inside and outside of Facebook have given talks about GraphQL at conf
 - [Learning GraphQL with React and Relay](https://www.packtpub.com/application-development/learning-graphql-react-and-relay-video) by Divyendu Singh
 - [Hands-on GraphQL for Better RESTful Web Services (Video)](https://www.packtpub.com/application-development/hands-graphql-better-restful-web-services-video) by Ashwin Hegde
 - [A PostgreSQL backed GraphQL BaaS](https://www.youtube.com/watch?v=neIZcc8y3B0) by Tanmai Gopal
+- [Explain Like I'm 5: GraphQL](https://www.youtube.com/watch?v=RDYYVGAKqqQ) by Jesslyn Tannady
 
 ## Books
 


### PR DESCRIPTION
## Description
Here at Meta Open Source, we've been working on creating a series of short videos about open source projects, and we recently covered GraphQL. It would be great to add it to the list on the official site.