### PR TITLE
Add SpectaQL to the Code page's list of javascript tools

### DIFF
--- a/src/content/code/language-support/javascript/tools/spectaql.md
+++ b/src/content/code/language-support/javascript/tools/spectaql.md
@@ -1,0 +1,26 @@
+---
+name: SpectaQL
+description: SpectaQL generates static HTML documentation from a GraphQL schema.
+url: https://github.com/anvilco/spectaql
+github: anvilco/spectaql
+npm: "spectaql"
+---
+
+SpectaQL is a Node.js library that generates static documentation for a GraphQL schema using a variety of options:
+
+* From a live endpoint using the introspection query.
+* From a file containing an introspection query result.
+* From a file, files or glob leading to the schema definitions in SDL.
+
+Out of the box, SpectaQL generates a single 3-column HTML page and lets you choose between a couple built-in themes. A main goal of the project is to be easily and extremely customizable--it is themeable and just about everything can be overridden or customized.
+
+```sh
+npm install --dev spectaql
+# OR
+yarn add -D spectaql
+
+# Then generate your docs
+npm run spectaql my-config.yml
+# OR
+yarn spectaql my-config.yml
+```


### PR DESCRIPTION
## Description

Add [SpectaQL](https://github.com/anvilco/spectaql) to the Code page's list of javascript tools. 

I wasn't sure if this would be better in the JS tools section or in the general purpose tools section (or both?). It's written in node, but can be used for any graphql API.