### PR TITLE
Fixed javascript code snippet

### DIFF
--- a/src/content/code/language-support/javascript/server/graphql-js.md
+++ b/src/content/code/language-support/javascript/server/graphql-js.md
@@ -23,9 +23,11 @@ var schema = buildSchema(`
   }
 `);
 
-var root = { hello: () => 'Hello world!' };
+var rootValue = { hello: () => 'Hello world!' };
 
-graphql(schema, '{ hello }', root).then((response) => {
+var source = '{ hello }';
+
+graphql({ schema, source, rootValue }).then((response) => {
   console.log(response);
 });
 ```


### PR DESCRIPTION
## Description

The snippet was not correct, it throws this error:
Error: Expected undefined to be a GraphQL schema.

The reason is that we passed configuration as params of qraphql function, but the function takes only one param - an object of the parameters.

See type declaration of the function by permalink bellow
https://github.com/graphql/graphql-js/blob/c7d7026982ceee536900a24ae31235127560297a/src/graphql.ts#L70
