### PR TITLE
fix: fix marked package import

### DIFF
--- a/src/components/Marked/MiniGraphiQL.tsx
+++ b/src/components/Marked/MiniGraphiQL.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from "react"
-import marked from "marked"
+import { marked } from "marked"
 
 import { graphql, formatError, parse, typeFromAST } from "graphql"
 


### PR DESCRIPTION
<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->
fix `marked` package import

## Description
In `Introspection` section, entering `queryType` in the input box will throw an error as shown in the figure. 
![image](https://user-images.githubusercontent.com/34960995/169760850-2732dfcc-0dcb-4e46-bd0c-7b16d7ea8f6b.png)
The reason is that the marked package used does not have a default export

<!-- Write a brief description of the changes introduced by this PR -->