### PR TITLE
Remove broken link to GraphQL Conf

### DIFF
--- a/src/content/foundation/GraphQLConf.md
+++ b/src/content/foundation/GraphQLConf.md
@@ -8,7 +8,7 @@ permalink: /foundation/graphql-conf/
 next: /foundation/community-grant/
 ---
 
-The GraphQL Foundation's inaugural [GraphQL Conf](https://conf.graphql.org) will be co-located with [OpenJS World](https://events.linuxfoundation.org/openjs-world/) and [cdCon](https://events.linuxfoundation.org/cdcon/) in Austin, TX on June 7-8, 2022. This collaborator summit-style event will be an opportunity for core GraphQL spec and implementation developers to meet in-person, discuss recent work, and plan for the future. All attendees of OpenJS World and CDcon are welcome.
+The GraphQL Foundation's inaugural GraphQL Conf will be co-located with [OpenJS World](https://events.linuxfoundation.org/openjs-world/) and [cdCon](https://events.linuxfoundation.org/cdcon/) in Austin, TX on June 7-8, 2022. This collaborator summit-style event will be an opportunity for core GraphQL spec and implementation developers to meet in-person, discuss recent work, and plan for the future. All attendees of OpenJS World and CDcon are welcome.
 
 Talks are expected to include:
 


### PR DESCRIPTION
## Description

This web page:

https://graphql.org/foundation/graphql-conf/

Links to:

https://conf.graphql.org/

Which forwards to

https://graphql.org/community/graphql-conf

Which does not exist. 

I propose we remove the link (until the `conf.graphql.org` URL is fixed) since it seems to be intended to be a self-reference?

---

Spotted by @michaelstaib; reported via Discord: https://discord.com/channels/625400653321076807/863136614997819393/978214478678216754