### PR TITLE
Add Escape.tech – GraphQL Security, GraphQL.Security & GraphQL Armor 

### DIFF
--- a/src/content/code/services/escape.md
+++ b/src/content/code/services/escape.md
@@ -1,0 +1,5 @@
+---
+name: Escape – GraphQL Security
+description: Live GraphQL Security & Compliance. Ensure your GraphQL endpoints are production-ready. During development. Without needed configuration. Supports every language and framework. Free to get started.
+url: https://escape.tech/
+---

--- a/src/content/code/services/graphql.security.md
+++ b/src/content/code/services/graphql.security.md
@@ -1,0 +1,5 @@
+---
+name: GraphQL.Security
+description: Fast and free security scan to run a dozen of tests on a GraphQL endpoint. No login is required.
+url: https://graphql.security/
+---

--- a/src/content/code/tools/graphql-armor.md
+++ b/src/content/code/tools/graphql-armor.md
@@ -1,0 +1,6 @@
+---
+name: GraphQL Armor
+description: The missing GraphQL security security layer for Apollo GraphQL and Yoga / Envelop servers.
+url: https://github.com/Escape-Technologies/graphql-armor
+github: "@Escape-Technologies/graphql-armor"
+---


### PR DESCRIPTION
## Description

This PR erases and replaces this one: https://github.com/graphql/graphql.github.io/pull/1253

Adding 2 security services and one tool developed and maintained by https://escape.tech/ 