### PR TITLE
Prevent translation of code blocks by wrapping them in <code> tag

### DIFF
--- a/src/components/Prism/index.tsx
+++ b/src/components/Prism/index.tsx
@@ -16,20 +16,22 @@ const Basic = ({ code, language }: Props) => (
     Prism={Prism}
   >
     {({ className, tokens, getLineProps, getTokenProps }: any) => (
-      <pre className={"prism " + className}>
-        {tokens.map((line, i) => {
-          if (line.length === 1 && line[0].content === "") {
-            line[0].content = " "
-          }
-          return (
-            <div {...getLineProps({ line, key: i })} style={{}}>
-              {line.map((token, key) => (
-                <span {...getTokenProps({ token, key })} style={{}} />
-              ))}
-            </div>
-          )
-        })}
-      </pre>
+      <code>
+        <pre className={"prism " + className}>
+          {tokens.map((line, i) => {
+            if (line.length === 1 && line[0].content === "") {
+              line[0].content = " "
+            }
+            return (
+              <div {...getLineProps({ line, key: i })} style={{}}>
+                {line.map((token, key) => (
+                  <span {...getTokenProps({ token, key })} style={{}} />
+                ))}
+              </div>
+            )
+          })}
+        </pre>
+      </code>
     )}
   </Highlight>
 )


### PR DESCRIPTION
<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

✋ 

Closes [#3561](https://github.com/graphql/graphql-js/issues/3561)

## Description

When using google translate on the docs website, it translates everything including the code examples.
This PR wraps all the code blocks with `<code>` tag that prevents google translate from translating the contents of code examples.

## Screenshots
Translation to french using google translate extension.

Before, `npm install` code block is translated:

<img width="783" alt="Screenshot 2022-10-30 at 14 12 13" src="https://user-images.githubusercontent.com/36277508/198883572-ebd5806f-f3c6-4642-9a44-244cdbea799c.png">

After, `npm install` code block is not translated:

<img width="800" alt="Screenshot 2022-10-30 at 14 12 22" src="https://user-images.githubusercontent.com/36277508/198883576-1792a4f9-1803-46d4-b46f-8a379c0ffb37.png">


<!-- Write a brief description of the changes introduced by this PR -->