### PR TITLE
Remove https from localhost based link name

### DIFF
--- a/src/content/graphql-js/Tutorial-ExpressGraphQL.md
+++ b/src/content/graphql-js/Tutorial-ExpressGraphQL.md
@@ -50,7 +50,7 @@ You can run this GraphQL server with:
 node server.js
 ```
 
-Since we configured `graphqlHTTP` with `graphiql: true`, you can use the GraphiQL tool to manually issue GraphQL queries. If you navigate in a web browser to [https://localhost:4000/graphql](http://localhost:4000/graphql), you should see an interface that lets you enter queries. It should look like:
+Since we configured `graphqlHTTP` with `graphiql: true`, you can use the GraphiQL tool to manually issue GraphQL queries. If you navigate in a web browser to [http://localhost:4000/graphql](http://localhost:4000/graphql), you should see an interface that lets you enter queries. It should look like:
 
 ![hello world graphql example](/img/hello.png)
 


### PR DESCRIPTION
Fix typo in #1265 - the link source is correct (http) but the link name is incorrectly specifying https.