### PR TITLE
Return type name in resolveType

### DIFF
--- a/src/components/Marked/swapiSchema.tsx
+++ b/src/components/Marked/swapiSchema.tsx
@@ -383,10 +383,10 @@ const resolvers = {
   Character: {
     __resolveType(data, context, info){
       if(humanData[data.id]){
-        return info.schema.getType('Human');
+        return 'Human';
       }
       if(droidData[data.id]){
-        return info.schema.getType('Droid');
+        return 'Droid';
       }
       return null;
     },
@@ -467,13 +467,13 @@ const resolvers = {
   SearchResult: {
     __resolveType(data, context, info){
       if(humanData[data.id]){
-        return info.schema.getType('Human');
+        return 'Human';
       }
       if(droidData[data.id]){
-        return info.schema.getType('Droid');
+        return 'Droid';
       }
       if(starshipData[data.id]){
-        return info.schema.getType('Starship');
+        return 'Starship';
       }
       return null;
     },


### PR DESCRIPTION
Closes #1310

[In this PR](https://github.com/graphql/graphql.github.io/pull/1293) we updated GraphQL.js to 16 which removed the support for returning a `GraphQLObjectType` from `resolveType`.

I've changed the code to return the type name directly :)

The error was this:

```
{
  "errors": [
    {
      "message": "Support for returning GraphQLObjectType from resolveType was removed in graphql-js@16.0.0 please return type name instead.",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "hero"
      ]
    }
  ],
  "data": {
    "hero": null
  }
}
```

and is visible here: https://graphql.org/learn/queries/