### PR TITLE
GraphQL Discord is now well established

### DIFF
--- a/src/content/community/Community-Users.md
+++ b/src/content/community/Community-Users.md
@@ -38,10 +38,8 @@ Please be patient and polite. These are not explicitly user support channels, al
 <div style="float:right;"><iframe src="https://discordapp.com/widget?id=625400653321076807&theme=dark" width="350" height="250" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe></div>
 
 * [GraphQL Foundation Discord](https://discord.graphql.org)
-  * We're in the process of moving our official chat to Discord, but you may find historical discussion in ~~[#general on the GraphQL Slack](https://graphql.slack.com/messages/general/) [(Get an invite)](https://graphql-slack.herokuapp.com/)~~.
 * [GraphQL Reddit Community](https://www.reddit.com/r/graphql/)
 * [GraphQL Community Facebook Group](https://www.facebook.com/groups/graphql.community/)
-* [Everything GraphQL: Curated By The Guild](https://discord.gg/xud7bH9)
 * [#help-graphql on the ReactiFlux Discord](http://join.reactiflux.com/)
 * [#graphql on freenode IRC](https://freenode.net/)
 


### PR DESCRIPTION
## Description

The GraphQL Discord was adopted September last year; it was previously the `Everything GraphQL: Curated By The Guild` server (i.e. they're the same place). So I've removed the redundant link, and I've also removed the link to the old Slack because people should not be going there any more (and we don't have any moderation of it).