### PR TITLE
Remove Slack

### DIFF
--- a/src/content/community/Community-Resources.md
+++ b/src/content/community/Community-Resources.md
@@ -22,7 +22,6 @@ Please follow these channels for updates and information:
 * **Twitter:** [@graphql](https://twitter.com/graphql)
 * **GitHub:** [github.com/graphql](https://github.com/graphql)
 * **Discord** [discord.graphql.org](https://discord.graphql.org)
-  * We're in the process of moving our official chat to Discord, but you may find historical discussion on ~~**Slack:** [slack.graphql.org](https://slack.graphql.org) ([get an invite](https://slack-invite.graphql.org))~~.
 * **Facebook Group:** [fb.com/groups/graphql.community/](https://www.facebook.com/groups/graphql.community/)
 * **Google Calendar:** [calendar.graphql.org](https://calendar.graphql.org)
 * **Blog:** [graphql.org/blog](/blog/)


### PR DESCRIPTION
There's no historical data in Slack due to it's lack of data retention and the Discord move was ages ago.