### PR TITLE
Update HelloWorld GraphQL Java example and add tutorial links

### DIFF
--- a/src/content/code/language-support/java-kotlin-android/server/graphql-java.md
+++ b/src/content/code/language-support/java-kotlin-android/server/graphql-java.md
@@ -5,6 +5,8 @@ url: https://github.com/graphql-java/graphql-java
 github: graphql-java/graphql-java
 ---
 
+See the [Getting Started tutorial](https://www.graphql-java.com/tutorials/getting-started-with-spring-boot) on the GraphQL Java website.
+
 Code that executes a hello world GraphQL query with `graphql-java`:
 
 ```java
@@ -22,12 +24,12 @@ import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring;
 public class HelloWorld {
 
     public static void main(String[] args) {
-        String schema = "type Query{hello: String} schema{query: Query}";
+        String schema = "type Query{hello: String}";
 
         SchemaParser schemaParser = new SchemaParser();
         TypeDefinitionRegistry typeDefinitionRegistry = schemaParser.parse(schema);
 
-        RuntimeWiring runtimeWiring = new RuntimeWiring()
+        RuntimeWiring runtimeWiring = newRuntimeWiring()
                 .type("Query", builder -> builder.dataFetcher("hello", new StaticDataFetcher("world")))
                 .build();
 
@@ -43,5 +45,4 @@ public class HelloWorld {
 }
 ```
 
-See [the graphql-java docs](https://github.com/graphql-java/graphql-java) for more information on setup.
-
+See [the graphql-java docs](https://www.graphql-java.com/documentation/master/getting-started) for further information.

--- a/src/content/code/language-support/java-kotlin-android/server/spring-graphql.md
+++ b/src/content/code/language-support/java-kotlin-android/server/spring-graphql.md
@@ -5,7 +5,7 @@ url: https://spring.io/projects/spring-graphql
 github: spring-projects/spring-graphql
 ---
 Spring for GraphQL provides support for Spring applications built on
-[GraphQL Java](https://www.graphql-java.com/).
+[GraphQL Java](https://www.graphql-java.com/). See the official [Spring guide](https://spring.io/guides/gs/graphql-server/) for how to build a GraphQL service in 15 minutes.
 
 * It is a joint collaboration between the GraphQL Java team and Spring engineering.
 * Our shared philosophy is to provide as little opinion as we can while focusing on comprehensive support for a wide range of use cases.


### PR DESCRIPTION
This PR updates the GraphQL Java example, the old one used a removed method.

I also update the GraphQL Java and Spring for GraphQL tutorial links.