### PR TITLE
fix: update broken graphql spec link

### DIFF
--- a/src/content/learn/BestPractice-ServingOverHTTP.md
+++ b/src/content/learn/BestPractice-ServingOverHTTP.md
@@ -69,7 +69,7 @@ Regardless of the method by which the query and variables were sent, the respons
 }
 ```
 
-If there were no errors returned, the `"errors"` field should not be present on the response. If no data is returned, [according to the GraphQL spec](http://facebook.github.io/graphql/#sec-Data), the `"data"` field should only be included if no errors occurred during execution.
+If there were no errors returned, the `"errors"` field should not be present on the response. If no data is returned, [according to the GraphQL spec](https://spec.graphql.org/October2021/#sec-Data), the `"data"` field should only be included if no errors occurred during execution.
 
 ## GraphiQL
 GraphiQL is useful during testing and development but should be disabled in production by default. If you are using express-graphql, you can toggle it based on the NODE_ENV environment variable:


### PR DESCRIPTION
<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #1331

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR changes the broken anchor link "according to the GraphQL spec" from `http://facebook.github.io/graphql/#sec-Data` to ` https://spec.graphql.org/October2021/#sec-Data`.
