### PR TITLE
Sponsor page: Add new `Ready to sign` button

### DIFF
--- a/src/pages/conf/sponsor.tsx
+++ b/src/pages/conf/sponsor.tsx
@@ -5,6 +5,26 @@ import LayoutConf from "../../components/Conf/Layout"
 import ButtonConf from "../../components/Conf/Button"
 import SeoConf from "../../components/Conf/Seo"
 
+type Button = {
+  href: string
+  text: string
+}
+
+const Buttons: Button[]  = [
+  {
+    href: "https://events.linuxfoundation.org/wp-content/uploads/2023/03/sponsor_GraphQLConf_2023_032423.pdf",
+    text: "Explore Sponsorship Opportunity",
+  },
+  {
+    href: "https://powerforms.docusign.net/ba1e05a3-244d-4c94-9b3a-fd769966e479?env=na3&acct=f30e10ec-fea1-4dd8-a262-384a61edabb5&accountId=f30e10ec-fea1-4dd8-a262-384a61edabb5",
+    text: "Ready To Sign",
+  },
+  {
+    href: "mailto:graphqlconf@graphql.org?subject=Sponsorships",
+    text: "Contact Us",
+  },
+]
+
 export default () => {
   return (
     <LayoutConf>
@@ -16,12 +36,9 @@ export default () => {
               <span className="block lg:inline">Sponsor GraphQLConf 2023</span>
             </div>
             <div className="flex justify-center items-center gap-4 flex-col sm:flex-row">
-              <ButtonConf href="https://events.linuxfoundation.org/wp-content/uploads/2023/03/sponsor_GraphQLConf_2023_032423.pdf">
-                Explore Sponsorship
-              </ButtonConf>
-              <ButtonConf href="mailto:graphqlconf@graphql.org?subject=Sponsorships">
-                Contact Us
-              </ButtonConf>
+              {Buttons.map((button) => (
+                <ButtonConf key={button.text } href={button.href}>{button.text}</ButtonConf>
+              )) }
             </div>
           </div>
           <div className="mx-auto max-w-prose mt-8">

--- a/src/pages/conf/sponsor.tsx
+++ b/src/pages/conf/sponsor.tsx
@@ -10,7 +10,7 @@ type Button = {
   text: string
 }
 
-const Buttons: Button[]  = [
+const Buttons: Button[] = [
   {
     href: "https://events.linuxfoundation.org/wp-content/uploads/2023/03/sponsor_GraphQLConf_2023_032423.pdf",
     text: "Explore Sponsorship Opportunity",
@@ -36,9 +36,11 @@ export default () => {
               <span className="block lg:inline">Sponsor GraphQLConf 2023</span>
             </div>
             <div className="flex justify-center items-center gap-4 flex-col sm:flex-row">
-              {Buttons.map((button) => (
-                <ButtonConf key={button.text } href={button.href}>{button.text}</ButtonConf>
-              )) }
+              {Buttons.map(button => (
+                <ButtonConf key={button.text} href={button.href}>
+                  {button.text}
+                </ButtonConf>
+              ))}
             </div>
           </div>
           <div className="mx-auto max-w-prose mt-8">


### PR DESCRIPTION
Signed-off-by: TuvalSimha <tuval.simha@gmail.com>

<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #<issue number>

## Description

1. Add a new button to the `Sponsor` page - `Ready to sign`
2. Make code more clear and type safe

@Urigo 

![Screenshot 2023-04-13 at 13 33 59](https://user-images.githubusercontent.com/37614975/231733276-b7d36cbb-1825-46a6-a8cb-50775e1b3cc7.png)


<!-- Write a brief description of the changes introduced by this PR -->
