### PR TITLE
fix conf page footer alignment

### DIFF
--- a/src/components/Conf/Footer/index.tsx
+++ b/src/components/Conf/Footer/index.tsx
@@ -53,23 +53,21 @@ const FooterConf = () => {
           ))}
         </div>
       </div>
-      <div>
-        <div className="container mt-5 sm:mt-0 py-4 flex flex-wrap flex-col sm:flex-row">
-          <p className="text-white text-sm text-center sm:text-left">
-            Copyright © {`${new Date().getFullYear()}`} The GraphQL Foundation.
-            All rights reserved.
-            <br />
-            For web site terms of use, trademark policy and general project
-            policies please see&nbsp;
-            <a href="https://lfprojects.org" target="_blank">
-              https://lfprojects.org
-            </a>
-            .
-          </p>
-          <span className="inline-flex sm:ml-auto sm:mt-0 mt-2 justify-center sm:justify-start ">
-            <SocialIcons />
-          </span>
-        </div>
+      <div className="container px-5 mt-5 sm:mt-0 py-4 flex flex-wrap flex-col sm:flex-row">
+        <p className="text-white text-sm text-center sm:text-left">
+          Copyright © {`${new Date().getFullYear()}`} The GraphQL Foundation.
+          All rights reserved.
+          <br />
+          For web site terms of use, trademark policy and general project
+          policies please see&nbsp;
+          <a href="https://lfprojects.org" target="_blank">
+            https://lfprojects.org
+          </a>
+          .
+        </p>
+        <span className="inline-flex sm:ml-auto sm:mt-0 mt-2 justify-center sm:justify-start items-start">
+          <SocialIcons />
+        </span>
       </div>
     </footer>
   )

--- a/src/components/Conf/SocialIcons/index.tsx
+++ b/src/components/Conf/SocialIcons/index.tsx
@@ -7,7 +7,7 @@ const SocialIcons = () => {
   return (
     <>
       <a
-        className="ml-5 mt-3 text-white cursor-pointer"
+        className="mt-3 text-white cursor-pointer"
         href="https://github.com/graphql"
         target="_blank"
       >


### PR DESCRIPTION
The footer alignment on the conf page was a bit off. (Mobile view stays the same)

Before:
<img width="1204" alt="CleanShot 2023-04-18 at 11 10 47@2x" src="https://user-images.githubusercontent.com/9019397/232823852-62cfe09f-11a6-4e05-a793-3e4e7eda125a.png">

After:
<img width="954" alt="CleanShot 2023-04-18 at 11 19 57@2x" src="https://user-images.githubusercontent.com/9019397/232824081-e9502863-4c82-4fef-b86a-bb67cd055eb8.png">


