### PR TITLE
Website/conf: Add a deep link for the sponsors section (#1438)

### DIFF
--- a/src/components/Conf/Sponers/index.tsx
+++ b/src/components/Conf/Sponers/index.tsx
@@ -52,7 +52,7 @@ const sponsorSilver: Image[] = [
 
 const SponsersConf = () => {
   return (
-    <div className="bg-white py-10 static">
+    <div id="sponsors" className="bg-white py-10 static">
       <h1 className="text-center text-4xl text-[#171E26] font-bold my-8">
         Sponsors
       </h1>


### PR DESCRIPTION
Closes #1438 

## Description
Adds a deep link to the sponsor's section

![sponsor-deeplink](https://github.com/graphql/graphql.github.io/assets/14279061/8ca16c59-f962-42fe-bed2-d7e98bec7ecb)
