### PR TITLE
Fix typos on GraphQLConf banner

### DIFF
--- a/src/pages/conf/index.tsx
+++ b/src/pages/conf/index.tsx
@@ -33,7 +33,7 @@ export default () => {
                 </div>
                 <div className="flex gap-2 items-center mb-6 font-medium">
                   <GlobeIcon />
-                  <span>San Fransisco Bay Area, CA</span>
+                  <span>San Francisco Bay Area, CA</span>
                 </div>
               </div>
               <div className="flex justify-center gap-4 flex-row">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,7 +24,7 @@ export default ({ pageContext }: PageProps<{}, { sourcePath: string }>) => {
               The offical GraphQL conference, by the GraphQL Foundation
             </span>
             <span className="mt-2 font-bold">
-              SEPTEMBER 19-21, 2023 • SAN FRANCISO BAY AREA, CA
+              SEPTEMBER 19-21, 2023 • SAN FRANCISCO BAY AREA, CA
             </span>
             <div>
               <a className="button" href="/conf/#attend">


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #1451 

## Description

This change fixes a typo on the GraphQLConf banner (`FRANCISO --> FRANCISCO`)

<img width="523" alt="image" src="https://github.com/graphql/graphql.github.io/assets/17167488/ffebdd0d-bdff-4f03-9872-af6598078281">

One more typo on https://graphql.org/conf/, on the banner at the top of the page: `Fransisco` should be `Francisco`

<!-- Write a brief description of the changes introduced by this PR -->
