### PR TITLE
add graphql training courses from hasura

### DIFF
--- a/src/content/community/Community-Users.md
+++ b/src/content/community/Community-Users.md
@@ -19,6 +19,7 @@ A number of GraphQL training courses are available.
 - [How to GraphQL](https://www.howtographql.com): The Fullstack Tutorial for GraphQL
 - [Apollo Odyssey](https://apollographql.com/tutorials/): Interactive courses for building GraphQL applications with Apollo's toolset
 - [Yoga GraphQL Server Tutorial](https://the-guild.dev/graphql/yoga-server/tutorial): Open source tutorial for creating modern GraphQL Servers in Node, CF Workers, Deno and others
+- [GraphQL Tutorials](https://hasura.io/learn/): Real World Fullstack GraphQL tutorials for developers by Hasura
 
 ## Where to ask questions
 


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #<issue number>

## Description
Moving the original PR from https://github.com/graphql/graphql.github.io/pull/746 to here to avoid unrelated histories.

This PR adds GraphQL Tutorials to the training courses section. The tutorials are Open source.

<!-- Write a brief description of the changes introduced by this PR -->
