### PR TITLE
style: make speakers page 3 per row

### DIFF
--- a/src/assets/css/global.css
+++ b/src/assets/css/global.css
@@ -1,3 +1,7 @@
 /*@tailwind base;*/
 @tailwind components;
 @tailwind utilities;
+
+.override-prose-w-with-85ch {
+  max-width: 83ch;
+}

--- a/src/pages/conf/program.tsx
+++ b/src/pages/conf/program.tsx
@@ -10,13 +10,6 @@ export default () => {
   return (
     <LayoutConf>
       <HeaderConf />
-      <head>
-        <link
-          rel="preload"
-          href="//graphqlconf23.sched.com/js/embed.js"
-          as="script"
-        />
-      </head>
 
       <div className="bg-white">
         <div className="prose lg:prose-lg mx-auto py-10 max-sm:px-4 override-prose-w-with-85ch">

--- a/src/pages/conf/program.tsx
+++ b/src/pages/conf/program.tsx
@@ -31,7 +31,6 @@ export default () => {
             <Script
               type="text/javascript"
               src="//graphqlconf23.sched.com/js/embed.js"
-              strategy="idle"
             ></Script>
             {/* 
             <h2>Workshop Day</h2>

--- a/src/pages/conf/program.tsx
+++ b/src/pages/conf/program.tsx
@@ -10,8 +10,16 @@ export default () => {
   return (
     <LayoutConf>
       <HeaderConf />
+      <head>
+        <link
+          rel="preload"
+          href="//graphqlconf23.sched.com/js/embed.js"
+          as="script"
+        />
+      </head>
+
       <div className="bg-white">
-        <div className="prose lg:prose-lg mx-auto py-10 max-sm:px-4">
+        <div className="prose lg:prose-lg mx-auto py-10 max-sm:px-4 override-prose-w-with-85ch">
           <h1>GraphQLConf 2023 Program</h1>
           <section className="px-0 my-8">
             <h4>September 19-21, 2023 I San Francisco Bay Area, CA</h4>
@@ -30,6 +38,7 @@ export default () => {
             <Script
               type="text/javascript"
               src="//graphqlconf23.sched.com/js/embed.js"
+              strategy="idle"
             ></Script>
             {/* 
             <h2>Workshop Day</h2>


### PR DESCRIPTION

## Description

Makes the speakers page 3 per row instead of 2


### Before
<img width="1726" alt="CleanShot 2023-07-01 at 13 48 48@2x" src="https://github.com/graphql/graphql.github.io/assets/72823042/9a9ac95e-47c6-47fd-9f9a-c64ea8fb5347">

### After
<img width="1728" alt="CleanShot 2023-07-01 at 13 48 57@2x" src="https://github.com/graphql/graphql.github.io/assets/72823042/b54a682b-0b03-4a7c-bac2-3695dca22c09">
