### PR TITLE
docs: Add `graphql-http`

### DIFF
--- a/src/content/code/language-support/javascript/client/graphql-http.md
+++ b/src/content/code/language-support/javascript/client/graphql-http.md
@@ -1,0 +1,7 @@
+---
+name: GraphQL-HTTP
+description: Simple, pluggable, zero-dependency, GraphQL over HTTP spec compliant server, client and audit suite.
+url: https://github.com/graphql/graphql-http
+github: graphql/graphql-http
+npm: "graphql-http"
+---

--- a/src/content/code/language-support/javascript/server/graphql-http.md
+++ b/src/content/code/language-support/javascript/server/graphql-http.md
@@ -1,0 +1,7 @@
+---
+name: GraphQL-HTTP
+description: Simple, pluggable, zero-dependency, GraphQL over HTTP spec compliant server, client and audit suite.
+url: https://github.com/graphql/graphql-http
+github: graphql/graphql-http
+npm: "graphql-http"
+---

--- a/src/content/code/language-support/javascript/tools/graphql-http.md
+++ b/src/content/code/language-support/javascript/tools/graphql-http.md
@@ -1,0 +1,7 @@
+---
+name: GraphQL-HTTP
+description: Simple, pluggable, zero-dependency, GraphQL over HTTP spec compliant server, client and audit suite.
+url: https://github.com/graphql/graphql-http
+github: graphql/graphql-http
+npm: "graphql-http"
+---


### PR DESCRIPTION
The GraphQL over HTTP reference implementation of the server and the client. Also a compliance audit tool.

Not completely sure whether it belongs just in the "Tools" section or also in the "Server" and the "Client" sections. Since the library is actual all three. Thoughts?