### PR TITLE
Update quicktype.md

### DIFF
--- a/src/content/code/tools/quicktype/general/quicktype.md
+++ b/src/content/code/tools/quicktype/general/quicktype.md
@@ -2,6 +2,6 @@
 name: quicktype
 description: Generate types for GraphQL queries in TypeScript, Swift, golang, C#, C++, and more.
 url: https://quicktype.io/
-github: quicktype/quicktype
+github: glideapps/quicktype
 npm: "quicktype"
 ---


### PR DESCRIPTION
Seems like https://github.com/quicktype/quicktype is now https://github.com/glideapps/quicktype . Using old org name seems to result in GitHub API giving back empty result which seems to crash the builds

Closes #<issue number>

## Description

<!-- Write a brief description of the changes introduced by this PR -->
