### PR TITLE
fix: use component path to ensure edit page link works for root/index

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -104,7 +104,7 @@ export const onCreatePage: GatsbyNode["onCreatePage"] = async ({
   deletePage(page)
   let context = {
     ...page.context,
-    sourcePath: path.relative(__dirname, page.path),
+    sourcePath: path.relative(__dirname, page.component),
   }
   if (page.path === "/code" || page.path === "/code/") {
     const markdownFilePaths = await glob("src/content/code/**/*.md")


### PR DESCRIPTION
In [78d6728](https://github.com/graphql/graphql.github.io/commit/78d67284635fde3fc45c7bb5425a49650ea71c89#diff-f5fdf00d27b2934559500edae0b37a71958a34e4584f097afeb95260144a761fL96), `onCreatePage` was updated to use `page.path` instead of `page.componentPath`. `page.path` is a member of the [`Page` interface](https://github.com/gatsbyjs/gatsby/blob/db41d1356c527cf4028142050978accd4abb1e9a/packages/gatsby/index.d.ts#L1779); `componentPath` is not.

The value of `page.path` for the site [home page](https://graphql.org/) is `/`. This means the "Edit Page" link in the Footer has an invalid path: The rendered `href` is `https://github.com/graphql/graphql.github.io/edit/source/../../../..`, but a browser follows the parent directory navigation path and leads to `https://github.com` 😁

`page.component` is part of the `Page` interface, and in my local testing/building of the site, seems to generate proper links for all pages...