### PR TITLE
Update fragment's definition in Learn-Queries.md

### DIFF
--- a/src/content/learn/Learn-Queries.md
+++ b/src/content/learn/Learn-Queries.md
@@ -110,6 +110,7 @@ That's why GraphQL includes reusable units called _fragments_. Fragments let you
   }
 }
 
+# used by the comparison UI component
 fragment comparisonFields on Character {
   name
   appearsIn
@@ -119,7 +120,7 @@ fragment comparisonFields on Character {
 }
 ```
 
-You can see how the above query would be pretty repetitive if the fields were repeated. The concept of fragments is frequently used to split complicated application data requirements into smaller chunks, especially when you need to combine lots of UI components with different fragments into one initial data fetch.
+You can see how the above query would be pretty repetitive if the fields were repeated. The concept of fragments is frequently used to define data requirements of a UI component or utility, creating smaller composable chunks. This is especially beneficial when you need to combine lots of UI components with different fragments into one initial data fetch.
 
 ### Using variables inside fragments
 

--- a/src/content/learn/Learn-Queries.md
+++ b/src/content/learn/Learn-Queries.md
@@ -110,7 +110,7 @@ That's why GraphQL includes reusable units called _fragments_. Fragments let you
   }
 }
 
-# used by the comparison UI component
+# used by the character-rendering UI component
 fragment comparisonFields on Character {
   name
   appearsIn


### PR DESCRIPTION
Updating the wording on how fragment should be used to nudge people towards a more scalable approach of using fragments to define data requirements.

## Description

Even though the spec allows fragments to be used however people see fit, the document should nudge people towards a better usage pattern that scales well. In this case, attempt to describe them as composable pieces of data requirements used by UI or utility code. I hope this isn't controversial.