### PR TITLE
Fix braces in Dgraph example query

### DIFF
--- a/src/code/services/dgraph.md
+++ b/src/code/services/dgraph.md
@@ -104,7 +104,7 @@ query {
       reviews(order: { desc: rating }, first: 10) {
         about {
           name
-          reviews(order: { asc: rating, first: 5 }) {
+          reviews(order: { asc: rating }, first: 5) {
             by {
               username
             }


### PR DESCRIPTION
The example query shown for Dgraph has the end brace in the wrong location.  This PR fixes it.

Thanks.