### PR TITLE
Language fix for Union Types under "Learn"

### DIFF
--- a/src/content/learn/Learn-Schema.md
+++ b/src/content/learn/Learn-Schema.md
@@ -297,7 +297,7 @@ Learn more about this in the [inline fragments](/learn/queries/#inline-fragments
 
 ### Union types
 
-Union types are very similar to interfaces, but they don't get to specify any common fields between the types.
+Union types are very similar to interfaces, but they don't get too specify about any common fields between the types.
 
 ```graphql
 union SearchResult = Human | Droid | Starship


### PR DESCRIPTION
## Description

This PR makes a textual change to fix spelling and add a missing word. Please see diff.

I ran the website locally and verified the fix, which was successful.