### PR TITLE
Remove `nodeVersion` from github actions, since it respects version from `.node-version` file

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -11,12 +11,11 @@ jobs:
       - uses: the-guild-org/shared-config/setup@main
         name: setup env
         with:
-          nodeVersion: 20.9.0
           packageManager: pnpm
           workingDirectory: ./
           packageManagerVersion: 8.15.5
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm i
       - name: Run Prettier Check
         run: pnpm format:check


### PR DESCRIPTION
was confirmed by @dotansimha 