### PR TITLE
add `Powered by Nextra` link in footer

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -115,28 +115,38 @@ function Footer() {
             https://lfprojects.org
           </a>
         </p>
-        <ul className="flex gap-5">
-          {[
-            { url: "https://github.com/graphql", icon: GitHubIcon },
-            { url: "https://discord.graphql.org", icon: DiscordIcon },
-            { url: "https://twitter.com/graphql", icon: TwitterIcon },
-            {
-              url: "http://stackoverflow.com/questions/tagged/graphql",
-              icon: StackOverflowIcon,
-            },
-          ].map(({ url, icon: Icon }) => (
-            <li key={url}>
-              <a
-                href={url}
-                target="_blank"
-                rel="noreferrer"
-                className="hover:text-primary transition-colors"
-              >
-                <Icon className="h-5 w-auto *:fill-current" />
-              </a>
-            </li>
-          ))}
-        </ul>
+        <div className="flex flex-col gap-4 lg:items-end">
+          <ul className="flex gap-5">
+            {[
+              { url: "https://github.com/graphql", icon: GitHubIcon },
+              { url: "https://discord.graphql.org", icon: DiscordIcon },
+              { url: "https://twitter.com/graphql", icon: TwitterIcon },
+              {
+                url: "http://stackoverflow.com/questions/tagged/graphql",
+                icon: StackOverflowIcon,
+              },
+            ].map(({ url, icon: Icon }) => (
+              <li key={url}>
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="hover:text-primary transition-colors block"
+                >
+                  <Icon className="h-5 w-auto *:fill-current" />
+                </a>
+              </li>
+            ))}
+          </ul>
+          <a
+            href="https://nextra.site"
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs hover:text-primary transition-colors"
+          >
+            Powered by Nextra
+          </a>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
### on desktop

<img width="1645" alt="image" src="https://github.com/graphql/graphql.github.io/assets/7361780/626eac5b-fe41-4a99-a61c-26b9ec52aa20">

### on mobile

<img width="569" alt="image" src="https://github.com/graphql/graphql.github.io/assets/7361780/1ecefcf5-d8e1-4511-b9e4-d15869961abe">
