### PR TITLE
rename `Community Resources` to `Resources` for consistency

### DIFF
--- a/src/pages/_meta.tsx
+++ b/src/pages/_meta.tsx
@@ -21,7 +21,7 @@ export default {
     title: "Community",
     items: {
       index: {
-        title: "Community Resources",
+        title: "Resources",
         href: "/community/resources/official-channels",
       },
       events: { title: "Events & Meetups" },


### PR DESCRIPTION
<img width="519" alt="image" src="https://github.com/graphql/graphql.github.io/assets/7361780/8eca2e9d-7157-4f66-ab53-bddd79171426">
