### PR TITLE
docs: Add more links from queries to schema

### DIFF
--- a/src/pages/learn/queries.mdx
+++ b/src/pages/learn/queries.mdx
@@ -205,7 +205,7 @@ All declared variables must be either scalars, enums, or input object types. So 
 
 Variable definitions can be optional or required. In the case above, since there isn't an `!` next to the `Episode` type, it's optional. But if the field you are passing the variable into requires a non-null argument, then the variable has to be required as well.
 
-To learn more about the syntax for these variable definitions, it's useful to learn the GraphQL schema language. The schema language is explained in detail on the Schema page.
+To learn more about the syntax for these variable definitions, it's useful to learn [the GraphQL schema language](/learn/schema). The schema language is explained in detail on [the Schemas and Types page](/learn/schema).
 
 ### Default variables
 


### PR DESCRIPTION
## Description

Adds two more links from the "Queries and Mutations" learning page to the "Schemas and Types" pages where I think it would be relevant for folks to want to be able to click through and learn more.