### PR TITLE
Argument need not be optional to have a default value defined

### DIFF
--- a/src/pages/learn/schema.mdx
+++ b/src/pages/learn/schema.mdx
@@ -63,7 +63,7 @@ type Starship {
 
 All arguments are named. Unlike languages like JavaScript and Python where functions take a list of ordered arguments, all arguments in GraphQL are passed by name specifically. In this case, the `length` field has one defined argument, `unit`.
 
-Arguments can be either required or optional. When an argument is optional, we can define a _default value_ - if the `unit` argument is not passed, it will be set to `METER` by default.
+Arguments can be either required or optional. We can define a _default value_ for an argument as well - if the `unit` argument is not passed, it will be set to `METER` by default.
 
 ## The Query and Mutation types
 


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #<issue number>

## Description
Current documentation about Arguments says that _"When an argument is optional, we can define a default value ..."_
This seems to be misleading because a default value for an argument can be defined irrespective of optional or mandatory argument.
<!-- Write a brief description of the changes introduced by this PR -->
