### PR TITLE
Use 2024 Sponsors component in FAQ

### DIFF
--- a/src/app/conf/2024/faq/page.tsx
+++ b/src/app/conf/2024/faq/page.tsx
@@ -1,5 +1,5 @@
 import FAQ from "./client-mdx"
-import { Sponsors } from "../../_components/sponsors"
+import { Sponsors } from "../sponsors"
 
 import { Metadata } from "next"
 


### PR DESCRIPTION
## Description

h/t to Jen T at Apollo for flagging this 🙏🏻 

The FAQ page lists the 2023 sponsors - I believe this change should resolve the issue 🙏🏻 

I don't have permissions to authorize a build so if someone could validate this change that would be great (or add me to the team so I can do it myself)
