### PR TITLE
fix: broken schedule and session page styles

### DIFF
--- a/src/app/conf/2024/schedule/[id]/page.tsx
+++ b/src/app/conf/2024/schedule/[id]/page.tsx
@@ -122,7 +122,7 @@ export default function SessionPage({ params }: SessionProps) {
                 <div className="flex flex-wrap lg:flex-row flex-col gap-5 mt-8">
                   {event.speakers!.map(speaker => (
                     <div
-                      className={`flex items-center gap-3 w-full ${event?.speakers?.length || 0 > 1 ? "max-w-[320px]": ""}`}
+                      className={`flex items-center gap-3 w-full ${event?.speakers?.length || 0 > 1 ? "max-w-[320px]" : ""}`}
                       key={speaker.username}
                     >
                       <Avatar

--- a/src/app/conf/2024/schedule/[id]/page.tsx
+++ b/src/app/conf/2024/schedule/[id]/page.tsx
@@ -78,6 +78,7 @@ export default function SessionPage({ params }: SessionProps) {
   if (!event) {
     notFound()
   }
+
   // @ts-expect-error -- fixme
   event.speakers = (event.speakers || []).map(speaker =>
     speakers.find(s => s.username === speaker.username),

--- a/src/app/conf/2024/schedule/[id]/page.tsx
+++ b/src/app/conf/2024/schedule/[id]/page.tsx
@@ -119,10 +119,10 @@ export default function SessionPage({ params }: SessionProps) {
                     - {format(parseISO(event.event_end), "hh:mmaaaa 'PDT'")}
                   </span>
                 </div>
-                <div className="flex lg:flex-row flex-col sm:gap-5">
+                <div className="flex flex-wrap lg:flex-row flex-col gap-5 mt-8">
                   {event.speakers!.map(speaker => (
                     <div
-                      className="flex items-center gap-3"
+                      className={`flex items-center gap-3 w-full ${event?.speakers?.length || 0 > 1 ? "max-w-[320px]": ""}`}
                       key={speaker.username}
                     >
                       <Avatar

--- a/src/app/conf/_components/schedule/schedule-list.tsx
+++ b/src/app/conf/_components/schedule/schedule-list.tsx
@@ -63,7 +63,7 @@ function getSessionsByDay(
     }
     sessionsByDay[day] = {
       ...sessionsByDay[day],
-      [date]: sessions.sort((a, b) => a?.venue.localeCompare(b?.venue)),
+      [date]: sessions.sort((a, b) => (a?.venue ?? "").localeCompare(b?.venue ?? "")),
     }
   })
 
@@ -249,7 +249,7 @@ export function ScheduleList({
                                             d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"
                                           />
                                         </svg>
-                                        {session?.venue}
+                                        {session.venue}
                                       </span>
                                     </div>
                                   </div>

--- a/src/app/conf/_components/schedule/schedule-list.tsx
+++ b/src/app/conf/_components/schedule/schedule-list.tsx
@@ -63,7 +63,9 @@ function getSessionsByDay(
     }
     sessionsByDay[day] = {
       ...sessionsByDay[day],
-      [date]: sessions.sort((a, b) => (a?.venue ?? "").localeCompare(b?.venue ?? "")),
+      [date]: sessions.sort((a, b) =>
+        (a?.venue ?? "").localeCompare(b?.venue ?? ""),
+      ),
     }
   })
 

--- a/src/app/conf/_components/schedule/schedule-list.tsx
+++ b/src/app/conf/_components/schedule/schedule-list.tsx
@@ -63,7 +63,7 @@ function getSessionsByDay(
     }
     sessionsByDay[day] = {
       ...sessionsByDay[day],
-      [date]: sessions.sort((a, b) => a.venue.localeCompare(b.venue)),
+      [date]: sessions.sort((a, b) => a?.venue.localeCompare(b?.venue)),
     }
   })
 
@@ -249,7 +249,7 @@ export function ScheduleList({
                                             d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"
                                           />
                                         </svg>
-                                        {session.venue}
+                                        {session?.venue}
                                       </span>
                                     </div>
                                   </div>

--- a/src/app/conf/_components/schedule/session-list.tsx
+++ b/src/app/conf/_components/schedule/session-list.tsx
@@ -78,7 +78,9 @@ function getSessionsByDay(
     }
     sessionsByDay[day] = {
       ...sessionsByDay[day],
-      [date]: sessions.sort((a, b) => (a?.venue ?? "").localeCompare(b?.venue ?? "")),
+      [date]: sessions.sort((a, b) =>
+        (a?.venue ?? "").localeCompare(b?.venue ?? ""),
+      ),
     }
   })
 

--- a/src/app/conf/_components/schedule/session-list.tsx
+++ b/src/app/conf/_components/schedule/session-list.tsx
@@ -78,7 +78,7 @@ function getSessionsByDay(
     }
     sessionsByDay[day] = {
       ...sessionsByDay[day],
-      [date]: sessions.sort((a, b) => a.venue.localeCompare(b.venue)),
+      [date]: sessions.sort((a, b) => a?.venue.localeCompare(b?.venue)),
     }
   })
 

--- a/src/app/conf/_components/schedule/session-list.tsx
+++ b/src/app/conf/_components/schedule/session-list.tsx
@@ -16,7 +16,7 @@ export interface ScheduleSession {
   event_subtype: string
   event_type: string
   name: string
-  venue: string
+  venue?: string
   speakers?: SchedSpeaker[] | string
   files?: { name: string; path: string }[]
 }
@@ -78,7 +78,7 @@ function getSessionsByDay(
     }
     sessionsByDay[day] = {
       ...sessionsByDay[day],
-      [date]: sessions.sort((a, b) => a?.venue.localeCompare(b?.venue)),
+      [date]: sessions.sort((a, b) => (a?.venue ?? "").localeCompare(b?.venue ?? "")),
     }
   })
 

--- a/src/app/conf/_components/speakers/avatar.tsx
+++ b/src/app/conf/_components/speakers/avatar.tsx
@@ -20,7 +20,7 @@ export const Avatar: FC<Props> = ({ avatar, name, className, href }) => {
         src={avatar}
         alt={`${name} Profile Image`}
         style={{
-          margin: 0
+          margin: 0,
         }}
       />
     ) : (

--- a/src/app/conf/_components/speakers/avatar.tsx
+++ b/src/app/conf/_components/speakers/avatar.tsx
@@ -19,6 +19,9 @@ export const Avatar: FC<Props> = ({ avatar, name, className, href }) => {
         className={`${className}`}
         src={avatar}
         alt={`${name} Profile Image`}
+        style={{
+          margin: 0
+        }}
       />
     ) : (
       <div


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/1d230a5d-c97a-488e-8d3d-acbfc12f30d9)

after:
<img width="1728" alt="CleanShot 2024-08-15 at 12 50 39@2x" src="https://github.com/user-attachments/assets/59d270c4-c91d-4896-9d13-6b2bf92e8a63">


before:
<img width="1477" alt="CleanShot 2024-08-15 at 12 51 15@2x" src="https://github.com/user-attachments/assets/0221cf39-3815-45ec-81c1-65d5bfd6dcf4">

after:
<img width="1728" alt="CleanShot 2024-08-15 at 12 51 29@2x" src="https://github.com/user-attachments/assets/af794948-eb99-437a-97b9-ca8673a7d3c9">
