### PR TITLE
Add new python client library `ql`

### DIFF
--- a/src/code/language-support/python/client/ql.md
+++ b/src/code/language-support/python/client/ql.md
@@ -6,7 +6,7 @@ github: https://github.com/dsal3389/ql
 ---
 
 GraphQL client library, wrapped around pydantic classes for type validation,
-provide safe and simple way to query data from a GraphQL API.
+provides a safe and simple way to query data from a GraphQL API.
 
 Features:
 

--- a/src/code/language-support/python/client/ql.md
+++ b/src/code/language-support/python/client/ql.md
@@ -10,9 +10,9 @@ provides a safe and simple way to query data from a GraphQL API.
 
 Features:
 
-  * python objects to valid GraphQL string
-  * scalar query responses
-  * typesafety
+- python objects to valid GraphQL string
+- scalar query responses
+- type-safety
 
 ## Install
 

--- a/src/code/language-support/python/client/ql.md
+++ b/src/code/language-support/python/client/ql.md
@@ -5,15 +5,17 @@ url: https://dsal3389.github.io/ql/
 github: https://github.com/dsal3389/ql
 ---
 
-Graphql client library, wrapped around pydantic classes for type validation,
-provide safe and simple way to query data from a graphql api.
+GraphQL client library, wrapped around pydantic classes for type validation,
+provide safe and simple way to query data from a GraphQL API.
 
-features:
-  * python objects to valid graphql string
+Features:
+
+  * python objects to valid GraphQL string
   * scalar query responses
   * typesafety
 
-## install
+## Install
+
 ```console
 pip3 install pydantic-graphql
 ```

--- a/src/code/language-support/python/client/ql.md
+++ b/src/code/language-support/python/client/ql.md
@@ -1,6 +1,6 @@
 ---
 name: ql
-description: non intrusive python graphql client wrapped around pydantic.
+description: Non intrusive python GraphQL client wrapped around pydantic.
 url: https://dsal3389.github.io/ql/
 github: https://github.com/dsal3389/ql
 ---

--- a/src/code/language-support/python/client/ql.md
+++ b/src/code/language-support/python/client/ql.md
@@ -1,0 +1,19 @@
+---
+name: ql
+description: non intrusive python graphql client wrapped around pydantic.
+url: https://dsal3389.github.io/ql/
+github: https://github.com/dsal3389/ql
+---
+
+Graphql client library, wrapped around pydantic classes for type validation,
+provide safe and simple way to query data from a graphql api.
+
+features:
+  * python objects to valid graphql string
+  * scalar query responses
+  * typesafety
+
+## install
+```console
+pip3 install pydantic-graphql
+```


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Hi, I would like to add graphql client library I am currently working on `ql`.
