### PR TITLE
fix typo in pages/graphql-js/object-types.mdx

### DIFF
--- a/src/pages/graphql-js/object-types.mdx
+++ b/src/pages/graphql-js/object-types.mdx
@@ -12,7 +12,7 @@ type Query {
 }
 ```
 
-If we wanted to have more and more methods based on a random die over time, we could implement this with a `RandomDie` object type instead.
+If we wanted to have more and more methods based on a random dice over time, we could implement this with a `RandomDie` object type instead.
 
 ```graphql
 type RandomDie {
@@ -124,7 +124,7 @@ app.listen(4000)
 console.log("Running a GraphQL API server at localhost:4000/graphql")
 ```
 
-When you issue a GraphQL query against an API that returns object types, you can call multiple methods on the object at once by nesting the GraphQL field names. For example, if you wanted to call both `rollOnce` to roll a die once, and `roll` to roll a die three times, you could do it with this query:
+When you issue a GraphQL query against an API that returns object types, you can call multiple methods on the object at once by nesting the GraphQL field names. For example, if you wanted to call both `rollOnce` to roll a dice once, and `roll` to roll a dice three times, you could do it with this query:
 
 ```graphql
 {


### PR DESCRIPTION
## Description

This PR will fix a typo in the graphql-js/object-types page.
The typo: die -> dice
