### PR TITLE
Remove Prisma from Tools

### DIFF
--- a/src/code/services/prisma.md
+++ b/src/code/services/prisma.md
@@ -1,6 +1,0 @@
----
-name: Prisma
-description: Next-generation Node.js and TypeScript ORM with a built-in data loader, which can be used when building GraphQL backends. For more information, go to https://www.prisma.io/graphql
-url: https://www.prisma.io
-github: prisma/prisma
----


### PR DESCRIPTION
## Description

Prisma is GraphQL > Code > Tools is bit confusing, I think.
Yes, it can be used when writing GraphQL APIs, but so is Postgres. Both do not read, write or understand GraphQL.
