### PR TITLE
Create atproto-did for Bluesky handle

### DIFF
--- a/public/.well-known/atproto-did
+++ b/public/.well-known/atproto-did
@@ -1,0 +1,1 @@
+// Bluesky DID goes here

--- a/public/.well-known/atproto-did
+++ b/public/.well-known/atproto-did
@@ -1,1 +1,1 @@
-// Bluesky DID goes here
+did:plc:a65ga6opvhd2h453vwscrvil


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This is to connect the GraphQL Foundation Bluesky handle with `@graphql.org`

Essentially `https://graphql.org/.well-known/atproto-did` needs to exist and provide the value of `did:plc:a65ga6opvhd2h453vwscrvil`

I believe putting the `atproto-did` file in the `public/.well-known` directory in this repo should achieve that

Let me know if there is a more optimal way! Happy for others to take over alternatively 🙏

Thanks!
