### PR TITLE
fix: close hintUl on unfocus

### DIFF
--- a/src/components/marked/mini-graphiQL.tsx
+++ b/src/components/marked/mini-graphiQL.tsx
@@ -529,27 +529,26 @@ function onHasCompletion(cm, data, onHintInformationRender) {
       // removed from our wrapper and in turn remove the wrapper from the
       // original container.
       let onRemoveFn
-      const observer = new MutationObserver((mutationsList) => {
+      const observer = new MutationObserver(mutationsList => {
         for (const mutation of mutationsList) {
           // Check if the hintsUl element was removed
           if (mutation.removedNodes) {
-            mutation.removedNodes.forEach((node) => {
-              if (node === hintsUl) {                
+            mutation.removedNodes.forEach(node => {
+              if (node === hintsUl) {
                 // Cleanup logic
-                observer.disconnect(); // Stop observing
-                wrapper.parentNode.removeChild(wrapper);
-                wrapper = null;
-                information = null;
-                onRemoveFn = null;
+                observer.disconnect() // Stop observing
+                wrapper.parentNode.removeChild(wrapper)
+                wrapper = null
+                information = null
+                onRemoveFn = null
               }
-            });
+            })
           }
         }
-      });
-      
+      })
+
       // Start observing the wrapper for child node removals
-      observer.observe(wrapper, { childList: true, subtree: false });
-      
+      observer.observe(wrapper, { childList: true, subtree: false })
     }
 
     // Now that the UI has been set up, add info to information.

--- a/src/components/marked/mini-graphiQL.tsx
+++ b/src/components/marked/mini-graphiQL.tsx
@@ -166,7 +166,7 @@ class QueryEditor extends Component {
       },
       hintOptions: {
         schema: this.props.schema,
-        closeOnUnfocus: false,
+        closeOnUnfocus: true,
         completeSingle: false,
       },
       extraKeys: {
@@ -529,18 +529,27 @@ function onHasCompletion(cm, data, onHintInformationRender) {
       // removed from our wrapper and in turn remove the wrapper from the
       // original container.
       let onRemoveFn
-      wrapper.addEventListener(
-        "DOMNodeRemoved",
-        (onRemoveFn = event => {
-          if (event.target === hintsUl) {
-            wrapper.removeEventListener("DOMNodeRemoved", onRemoveFn)
-            wrapper.parentNode.removeChild(wrapper)
-            wrapper = null
-            information = null
-            onRemoveFn = null
+      const observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+          // Check if the hintsUl element was removed
+          if (mutation.removedNodes) {
+            mutation.removedNodes.forEach((node) => {
+              if (node === hintsUl) {                
+                // Cleanup logic
+                observer.disconnect(); // Stop observing
+                wrapper.parentNode.removeChild(wrapper);
+                wrapper = null;
+                information = null;
+                onRemoveFn = null;
+              }
+            });
           }
-        }),
-      )
+        }
+      });
+      
+      // Start observing the wrapper for child node removals
+      observer.observe(wrapper, { childList: true, subtree: false });
+      
     }
 
     // Now that the UI has been set up, add info to information.


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #1829 

## Description

Turns out the `DOMNodeRemoved` mutation event being used to remove the hintUl has been deprecated for a while and is only supported on few browsers like firefox. This PR changes the way the hintUl is being removed to use an intersectionObserver instead.
