### PR TITLE
Fix duplicated og:title

### DIFF
--- a/src/components/tools-and-libraries.tsx
+++ b/src/components/tools-and-libraries.tsx
@@ -168,16 +168,23 @@ export function CodePage({ allTags, data }: CodePageProps) {
 
   const [sort, setSort] = useState("popularity")
 
+  let description = `A collection of tools and libraries for GraphQL`
+  let title = "Tools and Libraries | GraphQL"
+  if (selectedTagsAsString) {
+    description += ` related to ${selectedTagsAsString}`
+    title = `${selectedTagsAsString} | ${title}`
+  }
+
   return (
     <>
       <NextHead>
-        <title>
-          {selectedTagsAsString ? selectedTagsAsString + " | " : ""}Tools and
-          Libraries | GraphQL
-        </title>
+        <title>{title}</title>
+        <meta property="og:title" content={title} key="meta-og-title" />
+        <meta name="description" content={description} key="meta-description" />
         <meta
-          name="description"
-          content={`A collection of tools and libraries for GraphQL${selectedTagsAsString ? ` related to ${selectedTagsAsString}` : ""}`}
+          property="og:description"
+          content={description}
+          key="meta-og-description"
         />
       </NextHead>
       <div className="container py-10 md:py-20">

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -179,11 +179,19 @@ export default {
     return (
       <>
         <title>{title}</title>
-        <meta property="og:title" content={title} />
+        <meta property="og:title" content={title} key="meta-og-title" />
         {description && (
           <>
-            <meta name="description" content={description} />
-            <meta property="og:description" content={description} />
+            <meta
+              name="description"
+              content={description}
+              key="meta-description"
+            />
+            <meta
+              property="og:description"
+              content={description}
+              key="meta-og-description"
+            />
           </>
         )}
         {canonical && <link rel="canonical" href={canonical} />}


### PR DESCRIPTION
When navigating between pages Next.js renders an extra `<meta property="og:title" content="..." />` without replacing the old one.

The solution was to add a `key` attribute. This makes sure meta elements are updated after navigating to a new page.