### PR TITLE
refactor: use lucide over heroicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@graphql-tools/schema": "10.0.13",
     "@headlessui/react": "^1.7.17",
-    "@heroicons/react": "^2.0.18",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-radio-group": "^1.1.3",
     "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,6 @@ importers:
       '@headlessui/react':
         specifier: ^1.7.17
         version: 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@heroicons/react':
-        specifier: ^2.0.18
-        version: 2.2.0(react@18.3.1)
       '@radix-ui/react-icons':
         specifier: ^1.3.0
         version: 1.3.2(react@18.3.1)
@@ -1116,11 +1113,6 @@ packages:
     peerDependencies:
       react: ^16 || ^17 || ^18
       react-dom: ^16 || ^17 || ^18
-
-  '@heroicons/react@2.2.0':
-    resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
-    peerDependencies:
-      react: '>= 16 || ^19.0.0-rc'
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -5932,10 +5924,6 @@ snapshots:
       client-only: 0.0.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@heroicons/react@2.2.0(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:

--- a/src/app/conf/_components/schedule/filters.tsx
+++ b/src/app/conf/_components/schedule/filters.tsx
@@ -1,6 +1,6 @@
 import { Menu, Popover, Transition } from "@headlessui/react"
-import { ChevronDownIcon, XMarkIcon } from "@heroicons/react/20/solid"
 import { clsx } from "clsx"
+import { ChevronDown, X } from "lucide-react"
 
 type FiltersProps = {
   categories: { name: string; options: string[] }[]
@@ -22,7 +22,7 @@ export function Filters({
           onClick={onReset}
           className="flex cursor-pointer items-center gap-x-2 rounded-md bg-gray-200 px-2 py-1 text-sm font-medium text-gray-700 hover:bg-gray-300 hover:text-gray-900"
         >
-          Reset filters <XMarkIcon className="inline-block size-4" />
+          Reset filters <X className="inline-block size-4" />
         </button>
       )}
       <Menu as="div" className="relative inline-block text-left">
@@ -68,7 +68,7 @@ export function Filters({
                   {filterState[section.name].length}
                 </span>
               ) : null}
-              <ChevronDownIcon
+              <ChevronDown
                 className="-mr-1 ml-1 size-5 shrink-0 text-gray-400 group-hover:text-gray-500"
                 aria-hidden="true"
               />


### PR DESCRIPTION
Lucide has much more options and I introduced it in part of Conf 2025. So removing Heroicons.

| Before | After | 
| -----|-------|
| ![CleanShot 2024-12-23 at 16 38 48@2x](https://github.com/user-attachments/assets/025476c5-db79-457e-827c-ee4e0bc91b8a) |![CleanShot 2024-12-23 at 16 38 22@2x](https://github.com/user-attachments/assets/19104102-9c9d-4aff-9a84-e8a6eb2730df) |



