### PR TITLE
refactor: use lucide over radix icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@graphql-tools/schema": "10.0.13",
     "@headlessui/react": "^1.7.17",
-    "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-radio-group": "^1.1.3",
     "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
     "@tailwindcss/typography": "^0.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,6 @@ importers:
       '@headlessui/react':
         specifier: ^1.7.17
         version: 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-icons':
-        specifier: ^1.3.0
-        version: 1.3.2(react@18.3.1)
       '@radix-ui/react-radio-group':
         specifier: ^1.1.3
         version: 1.1.3(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1485,11 +1482,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@radix-ui/react-icons@1.3.2':
-    resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
-    peerDependencies:
-      react: ^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc
 
   '@radix-ui/react-id@1.0.1':
     resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
@@ -6239,10 +6231,6 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.18
-
-  '@radix-ui/react-icons@1.3.2(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
 
   '@radix-ui/react-id@1.0.1(@types/react@18.3.18)(react@18.3.1)':
     dependencies:

--- a/src/app/conf/2023/page.tsx
+++ b/src/app/conf/2023/page.tsx
@@ -1,10 +1,10 @@
-import { GlobeIcon } from "@radix-ui/react-icons"
 import { Metadata } from "next"
 import { About } from "../_components/about"
 import { Speakers } from "../_components/speakers"
 import { Sponsors } from "../_components/sponsors"
 import { Thanks } from "../_components/thanks"
 import { CalendarIcon, GraphQLConf, HostedByGraphQLFoundation } from "@/icons"
+import { Globe } from "lucide-react"
 
 export const metadata: Metadata = {
   title: "GraphQLConf 2023 — Sept 19-21 • SF Bay Area",
@@ -38,7 +38,7 @@ function Hero() {
           </div>
           <span />
           <div className="flex items-center gap-5 max-md:gap-3">
-            <GlobeIcon className="size-6" />
+            <Globe className="size-6" />
             <span>San Francisco Bay Area, CA</span>
           </div>
         </div>


### PR DESCRIPTION
Same reason as #1908

| Before | After | 
| ------|------|
|![CleanShot 2024-12-23 at 17 02 12@2x](https://github.com/user-attachments/assets/718847c7-4472-449f-ac01-cb7170c91f1f) |![CleanShot 2024-12-23 at 17 01 47@2x](https://github.com/user-attachments/assets/5c59586a-e35a-4ad1-958e-03db48b7d37d) |



