### PR TITLE
add ts ignore for user schema

### DIFF
--- a/src/components/marked/users-schema.ts
+++ b/src/components/marked/users-schema.ts
@@ -67,6 +67,7 @@ const ImageType = new GraphQLObjectType({
 // @ts-expect-error -- fixme
 const FriendConnection = new GraphQLObjectType({
   name: "FriendConnection",
+  // @ts-expect-error -- fixme
   fields: () => ({
     totalCount: { type: GraphQLInt },
     friends: { type: new GraphQLList(UserType) },


### PR DESCRIPTION
Looks like in https://github.com/graphql/graphql.github.io/commit/8c1c3a76b577103a40570031697c82ece24184a4 we got one more new TS error for the dummy schema. Ignoring that error just like other sections

![image](https://github.com/user-attachments/assets/53407cf6-b468-4b16-bd56-d78035e44a74)
