### PR TITLE
add npm trend link

### DIFF
--- a/src/pages/community/resources/more-resources.mdx
+++ b/src/pages/community/resources/more-resources.mdx
@@ -5,6 +5,8 @@ To explore other community-developed resources and content about GraphQL, take a
 - [awesome-graphql](https://github.com/chentsulin/awesome-graphql): A fantastic community maintained collection of libraries, resources, and more.
 - [graphql-apis](https://github.com/APIs-guru/graphql-apis): A collective list of public GraphQL APIs.
 - [GraphQL Screencasts](https://graphql.wtf): Learn something new with GraphQL, every week.
+- [GraphQL Screencasts](https://graphql.wtf): Learn something new with GraphQL, every week.
+- [Usage trend of graphql package](https://npm-compare.com/graphql#timeRange=FIVE_YEARS): NPM Package Downloads Trend of `graphql`
 
 ## Community Meetups
 

--- a/src/pages/community/resources/more-resources.mdx
+++ b/src/pages/community/resources/more-resources.mdx
@@ -5,7 +5,6 @@ To explore other community-developed resources and content about GraphQL, take a
 - [awesome-graphql](https://github.com/chentsulin/awesome-graphql): A fantastic community maintained collection of libraries, resources, and more.
 - [graphql-apis](https://github.com/APIs-guru/graphql-apis): A collective list of public GraphQL APIs.
 - [GraphQL Screencasts](https://graphql.wtf): Learn something new with GraphQL, every week.
-- [GraphQL Screencasts](https://graphql.wtf): Learn something new with GraphQL, every week.
 - [Usage trend of graphql package](https://npm-compare.com/graphql#timeRange=FIVE_YEARS): NPM Package Downloads Trend of `graphql`
 
 ## Community Meetups


### PR DESCRIPTION
Dear GraphQL team,

I’d like to propose adding a NPM downloads trend link to the document. This link provides a clear visualization of the package’s growth in recent five years, which can be especially helpful for new users evaluating GraphQL’s popularity and reliability:

- [Usage trend of graphql package](https://npm-compare.com/graphql#timeRange=FIVE_YEARS): NPM Package Downloads Trend of graphql

By the way, as a maintainer of npm-compare.com, I’m also happy to implement any additional features that could further benefit graphql. Thank you for considering my PR, and I look forward to your feedback!