### PR TITLE
Rewrite requests to `/graphql`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -73,7 +73,7 @@ export default withLess(
       return [
         {
           source: "/swapi-graphql/:path*",
-          destination: "https://graphql.github.io/swapi-graphql/:path*",
+          destination: "https://graphql.github.io/swapi-graphql/graphql",
         },
       ]
     },


### PR DESCRIPTION
The swapi graphql demo has been broken for a while as it points to the netlify path returning a 301, this should be fixed by https://github.com/graphql/swapi-graphql/pull/232 but the link could look cleaner so instead this requests to /graphql