### PR TITLE
Fix SWAPI URL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -73,7 +73,7 @@ export default withLess(
       return [
         {
           source: "/swapi-graphql/:path*",
-          destination: "https://graphql.github.io/swapi-graphql/:path*",
+          destination: "https://swapi-graphql.netlify.app/:path*",
         },
       ]
     },

--- a/next.config.js
+++ b/next.config.js
@@ -75,6 +75,10 @@ export default withLess(
           source: "/swapi-graphql/:path*",
           destination: "https://swapi-graphql.netlify.app/:path*",
         },
+        {
+          source: "/graphql",
+          destination: "https://swapi-graphql.netlify.app/graphql",
+        },
       ]
     },
   }),


### PR DESCRIPTION
Looks like we are currently pointing to an older URL - trying it out in the preview in a bit