### PR TITLE
relax CORS for /graphql API route

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -69,18 +69,18 @@ export default withLess(
           headers: [
             {
               key: "Access-Control-Allow-Origin",
-              value: "*"
+              value: "*",
             },
             {
               key: "Access-Control-Allow-Methods",
-              value: "GET, POST, OPTIONS"
+              value: "GET, POST, OPTIONS",
             },
             {
               key: "Access-Control-Allow-Headers",
-              value: "Content-Type"
+              value: "Content-Type",
             },
-          ]
-        }
+          ],
+        },
       ]
     },
     trailingSlash: true,

--- a/next.config.js
+++ b/next.config.js
@@ -62,6 +62,27 @@ export default withLess(
       NEXT_PUBLIC_GA_ID:
         process.env.NODE_ENV === "production" ? "UA-44373548-16" : "",
     },
+    headers: async () => {
+      return [
+        {
+          source: "/graphql",
+          headers: [
+            {
+              key: "Access-Control-Allow-Origin",
+              value: "*"
+            },
+            {
+              key: "Access-Control-Allow-Methods",
+              value: "GET, POST, OPTIONS"
+            },
+            {
+              key: "Access-Control-Allow-Headers",
+              value: "Content-Type"
+            },
+          ]
+        }
+      ]
+    },
     trailingSlash: true,
     // Only for local development, skip 200 statusCode due following error:
     //


### PR DESCRIPTION
the underlying API we have allows CORS from anyone. There are folks who do use this as demo API so we should allow traffic