### PR TITLE
Add Apollo Router to the list of tools

### DIFF
--- a/src/code/tools/apollo/gateways-supergraphs/apollo-router.md
+++ b/src/code/tools/apollo/gateways-supergraphs/apollo-router.md
@@ -1,0 +1,17 @@
+---
+name: Apollo Router
+description: A configurable, high-performance routing runtime for Apollo Federation
+url: https://www.apollographql.com/
+github: apollographql/router
+---
+
+# Apollo Router Core
+
+The **Apollo Router Core** is a configurable, high-performance **graph router** written in Rust to run a [federated supergraph](https://www.apollographql.com/docs/federation/) that uses [Apollo Federation 2](https://www.apollographql.com/docs/federation/v2/federation-2/new-in-federation-2).
+
+Apollo Router Core is free, source-available, well-tested, regularly benchmarked, includes most major features of Apollo Gateway and is able to serve production-scale workloads.
+
+## GraphOS Router
+
+In conjunction with the [Apollo GraphOS platform](https://www.apollographql.com/docs/graphos/platform), GraphOS Router is the enterprise-grade runtime plane and a client's entry point to your federated supergraph.
+Configure it to secure your supergraph, monitor and optimize performance, extend functionality, and more.


### PR DESCRIPTION
## Description

Adds [Apollo Router](https://github.com/apollographql/router) to list of searchable tools for GraphQL Federation
