### PR TITLE
Improve flow of documentation around GraphiQL

### DIFF
--- a/src/pages/graphql-js/running-an-express-graphql-server.mdx
+++ b/src/pages/graphql-js/running-an-express-graphql-server.mdx
@@ -52,10 +52,12 @@ You can run this GraphQL server with:
 node server.js
 ```
 
+At this point you will have a running GraphQL API; but you can't just visit it in your web browser to use it - you need a GraphQL client to issue GraphQL queries to the API. Let's take a look at how to add the Graph_i_QL (GraphQL with an `i` in the middle) integrated development environment to your server.
+
 ## Using GraphiQL
 
-[GraphiQL](https://github.com/graphql/graphiql) is GraphQL's IDE; a great way of querying and exploring your GraphQL API.
-One easy way to add it to your server is via the MIT-licensed [ruru](https://github.com/graphile/crystal/blob/main/grafast/ruru/README.md) package which bundles a prebuilt GraphiQL with some popular enhancements.
+[Graph_i_QL](https://github.com/graphql/graphiql) is GraphQL's IDE; a great way of querying and exploring your GraphQL API.
+One easy way to add it to your server is via the MIT-licensed [ruru](https://github.com/graphile/crystal/blob/main/grafast/ruru/README.md) package which bundles a prebuilt Graph_i_QL with some popular enhancements.
 To do so, install the `ruru` module with `npm install --save ruru` and then add the following to your `server.js` file, then restart the `node server.js` command:
 
 ```js
@@ -69,6 +71,6 @@ app.get("/", (_req, res) => {
 ```
 
 If you navigate to [http://localhost:4000](http://localhost:4000), you should see an interface that lets you enter queries;
-now you can use the GraphiQL IDE tool to issue GraphQL queries directly in the browser.
+now you can use the Graph_i_QL IDE tool to issue GraphQL queries directly in the browser.
 
 At this point you have learned how to run a GraphQL server. The next step is to learn how to [issue GraphQL queries from client code](/graphql-js/graphql-clients/).

--- a/src/pages/graphql-js/running-an-express-graphql-server.mdx
+++ b/src/pages/graphql-js/running-an-express-graphql-server.mdx
@@ -52,12 +52,12 @@ You can run this GraphQL server with:
 node server.js
 ```
 
-At this point you will have a running GraphQL API; but you can't just visit it in your web browser to use it - you need a GraphQL client to issue GraphQL queries to the API. Let's take a look at how to add the Graph_i_QL (GraphQL with an `i` in the middle) integrated development environment to your server.
+At this point you will have a running GraphQL API; but you can't just visit it in your web browser to use it - you need a GraphQL client to issue GraphQL queries to the API. Let's take a look at how to add the GraphiQL (GraphQL with an `i` in the middle) integrated development environment to your server.
 
 ## Using GraphiQL
 
-[Graph_i_QL](https://github.com/graphql/graphiql) is GraphQL's IDE; a great way of querying and exploring your GraphQL API.
-One easy way to add it to your server is via the MIT-licensed [ruru](https://github.com/graphile/crystal/blob/main/grafast/ruru/README.md) package which bundles a prebuilt Graph_i_QL with some popular enhancements.
+[GraphiQL](https://github.com/graphql/graphiql) is GraphQL's IDE; a great way of querying and exploring your GraphQL API.
+One easy way to add it to your server is via the MIT-licensed [ruru](https://github.com/graphile/crystal/blob/main/grafast/ruru/README.md) package which bundles a prebuilt GraphiQL with some popular enhancements.
 To do so, install the `ruru` module with `npm install --save ruru` and then add the following to your `server.js` file, then restart the `node server.js` command:
 
 ```js
@@ -71,6 +71,6 @@ app.get("/", (_req, res) => {
 ```
 
 If you navigate to [http://localhost:4000](http://localhost:4000), you should see an interface that lets you enter queries;
-now you can use the Graph_i_QL IDE tool to issue GraphQL queries directly in the browser.
+now you can use the GraphiQL IDE tool to issue GraphQL queries directly in the browser.
 
 At this point you have learned how to run a GraphQL server. The next step is to learn how to [issue GraphQL queries from client code](/graphql-js/graphql-clients/).


### PR DESCRIPTION
Closes #1951

## Description

For someone following the tutorial they may well get as far as running the server (`node server.js`) and then attempt to visit their new API and get confused because they're met with an error such as `{"errors":[{"message":"Missing query"}]}`.

This PR adds some joining text to make it clear this is the expected outcome, and they must read on to get the GraphiQL IDE set up so that they can write queries.