### PR TITLE
Improve graphql-js.org redirects in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/graphql-js",
-      "destination": "https://graphql-js.org/docs",
+      "destination": "https://graphql-js.org",
       "permanent": true
     },
     {
@@ -52,7 +52,7 @@
     },
     {
       "source": "/graphql-js/:path*",
-      "destination": "https://graphql-js.org/:path*",
+      "destination": "https://graphql-js.org/docs/:path*",
       "permanent": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/graphql-js",
-      "destination": "https://graphql-js.org",
+      "destination": "https://graphql-js.org/docs",
       "permanent": true
     },
     {


### PR DESCRIPTION
Relates to #1957

## Description

It seems most of the graphql-js docs are at https://graphql-js.org/docs so by redirecting there links like the following should automatically work:

- https://graphql.org/graphql-js/graphql-clients
- https://graphql.org/graphql-js/running-an-express-graphql-server

cc @JoviDeCroock 