### PR TITLE
apollo-server documentation fix

### DIFF
--- a/src/code/language-support/javascript/server/apollo-server.md
+++ b/src/code/language-support/javascript/server/apollo-server.md
@@ -19,7 +19,7 @@ import { ApolloServer } from "@apollo/server"
 import { startStandaloneServer } from "@apollo/server/standalone"
 import { buildSchema } from "graphql"
 
-const schema = buildSchema(`
+const typeDefs = buildSchema(`
    type Query {
       hello: String
    }


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #<issue number>

## Description

`typeDefs` was undefined in the apollo-server documentation, so I renamed `schema` accordingly