### PR TITLE
Use "a" instead of "an"

### DIFF
--- a/src/pages/learn/schema.mdx
+++ b/src/pages/learn/schema.mdx
@@ -58,7 +58,7 @@ The language is readable, but let's go over it so that we can have a shared voca
 - `name` and `appearsIn` are [fields](#object-types-and-fields) on the `Character` type. That means that `name` and `appearsIn` are the only fields that can appear in any part of a GraphQL query that operates on the `Character` type.
 - `String` is one of the built-in [Scalar types](#scalar-types). These are types that resolve to a single scalar value and can't have sub-selections in the query. We'll go over Scalar types more later.
 - `String!` means that the field is a [Non-Null type](#non-null), meaning the GraphQL service promises to give you a value whenever you query this field. In SDL, we represent those with an exclamation mark.
-- `[Episode!]!` represents an [List type](#list) of `Episode` objects. When a List is Non-Null, you can always expect an array (with zero or more items) when you query the `appearsIn` field. In this case, since `Episode!` is also Non-Null within the list, you can always expect every item in the array to be an `Episode` object.
+- `[Episode!]!` represents a [List type](#list) of `Episode` objects. When a List is Non-Null, you can always expect an array (with zero or more items) when you query the `appearsIn` field. In this case, since `Episode!` is also Non-Null within the list, you can always expect every item in the array to be an `Episode` object.
 
 Now you know what a GraphQL Object type looks like and how to read the basics of SDL.
 


### PR DESCRIPTION
It is followed by a consonant sound.