### PR TITLE
new conf design — close mobile menu

### DIFF
--- a/src/app/conf/2025/components/navbar.tsx
+++ b/src/app/conf/2025/components/navbar.tsx
@@ -10,6 +10,7 @@ import { Badge } from "../../_components/badge"
 import MenuIcon from "../pixelarticons/menu.svg?svgr"
 import CloseIcon from "../pixelarticons/close.svg?svgr"
 import { GraphQLConfLogoLink } from "./graphql-conf-logo-link"
+import { Anchor } from "../../_design-system/anchor"
 
 export interface NavbarProps {
   links: { href: string; children: React.ReactNode; "aria-disabled"?: true }[]
@@ -79,19 +80,19 @@ export function Navbar({ links, year }: NavbarProps): ReactElement {
             <div className="flex w-full flex-col lg:mt-0 lg:block">
               {links.map(
                 ({ "aria-disabled": isDisabled, children, ...link }) => (
-                  <NextLink
+                  <Anchor
                     aria-disabled={isDisabled}
                     key={link.href}
                     {...link}
-                    // if external link, open in new tab
-                    {...(link.href.startsWith("https") && {
-                      target: "_blank",
-                      rel: "noopener noreferrer",
-                    })}
                     className={clsx(
                       "p-5 underline-offset-4 hover:underline aria-disabled:pointer-events-none max-lg:text-base",
                       pathname === link.href && "underline",
                     )}
+                    onClick={() => {
+                      if (mobileDrawerOpen) {
+                        setMobileDrawerOpen(false)
+                      }
+                    }}
                   >
                     {children}
                     {isDisabled && (
@@ -99,7 +100,7 @@ export function Navbar({ links, year }: NavbarProps): ReactElement {
                         <Badge className="text-white">Soon</Badge>
                       </sup>
                     )}
-                  </NextLink>
+                  </Anchor>
                 ),
               )}
             </div>

--- a/src/app/conf/2025/components/navbar.tsx
+++ b/src/app/conf/2025/components/navbar.tsx
@@ -31,6 +31,15 @@ export function Navbar({ links, year }: NavbarProps): ReactElement {
 
   useEffect(() => {
     document.body.style.overflow = mobileDrawerOpen ? "hidden" : "auto"
+    if (mobileDrawerOpen) {
+      const closeOnEscape = (event: KeyboardEvent) => {
+        if (event.key === "Escape") setMobileDrawerOpen(false)
+      }
+      document.addEventListener("keydown", closeOnEscape)
+      return () => {
+        document.removeEventListener("keydown", closeOnEscape)
+      }
+    }
   }, [mobileDrawerOpen])
 
   return (


### PR DESCRIPTION
## Description

We now close the navbar menu even if the link click doesn't lead to navigation.
We also close it on Escape keydown for narrow windows on desktops and tablets.

Thanks @n1ru4l for noticing it.