### PR TITLE
docs: add guide on graphql-http errors

### DIFF
--- a/src/pages/learn/_meta.ts
+++ b/src/pages/learn/_meta.ts
@@ -27,4 +27,5 @@ export default {
   performance: "",
   security: "",
   federation: "",
+  "debug-errors": "Common `graphql-http` Errors",
 }

--- a/src/pages/learn/_meta.ts
+++ b/src/pages/learn/_meta.ts
@@ -27,5 +27,9 @@ export default {
   performance: "",
   security: "",
   federation: "",
+  "-- 3": {
+    type: "separator",
+    title: "GraphQL over HTTP",
+  },
   "debug-errors": "Common `graphql-http` Errors",
 }

--- a/src/pages/learn/_meta.ts
+++ b/src/pages/learn/_meta.ts
@@ -31,5 +31,5 @@ export default {
     type: "separator",
     title: "GraphQL over HTTP",
   },
-  "debug-errors": "Common `graphql-http` Errors",
+  "debug-errors": "Common GraphQL over HTTP Errors",
 }

--- a/src/pages/learn/best-practices.mdx
+++ b/src/pages/learn/best-practices.mdx
@@ -53,5 +53,10 @@ The articles in this section should not be taken as gospel, and in some cases ma
       link: "/learn/security/",
       description: "Protect GraphQL APIs from malicious operations",
     },
+    {
+      title: "Common Errors",
+      link: "/learn/debug-errors/",
+      description: "Learn about common `graphql-http` errors and how to debug them.",
+    }
   ]}
 />

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -118,7 +118,11 @@ The HTTP layer succeeded, but the GraphQL request produced errors.
 
 ### How to debug
 
-Check the `errors` array in the response body. A typical response looks like:
+Check the `errors` array in the response body.
+
+If the response includes a `data` property then your query document is likely valid and you most likely hit a runtime exception - perhaps something went wrong on the server, you supplied invalid data, you're not allowed to do that, or some other runtime exception occurred.
+
+If the response does not include a `data` property it's likely there was a mistake in your request - an invalid GraphQL document or bad values for variables. A typical validation error response looks like:
 
 ```json
 {

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -1,4 +1,4 @@
-# Common `graphql-http` Errors and How to Debug Them
+# Common HTTP Errors and How to Debug Them
 
 When building or consuming a GraphQL API over HTTP, it's common to run into
 errors, especially during development. Understanding how to recognize and resolve these issues

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -39,7 +39,7 @@ and may allow `GET` for queries.
 ### Common causes
 
 - Sending a `PUT` or `DELETE` request instead of `POST` or `GET`
-- Sending a `GET` request for a mutation
+- Sending a `GET` request for a mutation, or to a server that only supports `POST` requests
 
 ### How to debug
 

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -1,0 +1,134 @@
+# Common `graphql-http` Errors and How to Debug Them
+
+When building or consuming a GraphQL API over HTTP, it's common to run into
+errors, especially during development. Understanding how to recognize and resolve these issues
+can save you time and frustration.
+
+This guide outlines common `graphql-http` errors, what they mean, and how to debug them 
+effectively. These examples assume you're using the 
+[GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/draft/)
+and an implementation such as [`graphql-http`](https://github.com/graphql/graphql-http) or any 
+server that follows the spec.
+
+## `400 Bad Request`: Syntax or parse errors
+
+### What it means
+
+The server couldn't parse your request. Either the GraphQL query string is malformed,
+or the JSON body isn't valid.
+
+### Common causes
+
+- JSON syntax errors
+- Sending a plain string without wrapping it in `{ "query": "..." }`
+- Using `Content-Type: application/graphql` without supporting it
+
+### How to debug
+
+- Validate your JSON body using a linter or formatter.
+- Make sure you're sending a `POST` request with a `Content-Type: application/json` header.
+- Verify that the GraphQL query is syntactically correct. Use an IDE or a linter to verify it.
+
+## `405 Method Not Allowed`: Wrong HTTP Method
+
+### What it means
+
+You're using an unsupported HTTP method. Most GraphQL servers require `POST` for mutations
+and may allow `GET` for queries.
+
+### Common causes
+
+- Sending a `PUT` or `DELETE` request instead of `POST` or `GET`
+- Sending a `GET` request for a mutation
+
+### How to debug
+
+- Check your HTTP method. Mutations must use `POST`.
+- Make sure your server supports `GET` for queries.
+- Refer to the [GraphQL over HTTP spec](https://graphql.github.io/graphql-over-http/draft/) to 
+confirm method support.
+
+## `415 Unsupported Media Type`
+
+### What it means
+
+The server doesn't understand the request's `Content-Type`.
+
+### Common causes
+
+- Sending a GraphQL query with `Content-Type: text/plain` or another unsupported type
+- Omitting the `Content-Type` header in a `POST` request
+
+### How to debug
+
+- Set the header explicitly: `Content-Type: application/json`.
+- If you're using `application/graphql`, verify your server supports it. This content type
+is optional.
+
+## `422 Unprocessable Entity`: Missing or invalid `query`
+
+### What it means
+
+The server received the request, but the `query` field was missing or invalid.
+
+### Common causes
+
+- Sending `{}` with no `query` key
+- Sending variables or an operation name without a query
+
+### How to debug
+
+Always include a `query` field in your request body. For example:
+
+```json
+{
+  "query": "{ user(id: 1) { name } }"
+}
+```
+
+## `500 Internal Server Error`: Unexpected server failures
+
+### What it means
+
+Something went wrong on the server. 
+
+### Common causes
+
+- An unhandled exception in a resolver
+- Schema validation issues during server startup
+- Missing or misconfigured middleware
+
+### How to debug
+
+- Check server logs or stack traces.
+- Add error handling to resolvers.
+
+## GraphQL errors with `200 OK`
+
+### What it means
+
+The HTTP layer succeeded, but the GraphQL response contains errors.
+
+### Common causes
+
+- Querying a field that doesn't exist
+- Passing incorrect arguments to a field
+- Violating schema constraints, such as non-nullability
+
+### How to debug
+
+Check the `errors` array in the response body. A typical response looks like:
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Cannot query field \"foo\" on type \"Query\".",
+      "locations": [{ "line": 1, "column": 3 }]
+    }
+  ]
+}
+```
+
+Compare your query against the schema using introspection or an IDE.

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -114,6 +114,7 @@ The HTTP layer succeeded, but the GraphQL request produced errors.
 - Querying a field that doesn't exist
 - Passing incorrect arguments to a field
 - Violating schema constraints, such as non-nullability
+- Runtime errors during execution
 
 ### How to debug
 

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -74,10 +74,17 @@ The HTTP layer succeeded, but the GraphQL operation produced errors.
 
 ### Common causes
 
+- Runtime errors during execution
+- Violating schema constraints (e.g. returning the wrong data type, or `null` in a non-nullable position)
+
+Older servers and clients (those not using
+`Content-Type: application/graphql-response+json`) may also use 200 OK in the case of
+complete request failure (no `data`). Common causes include:
+
 - Querying a field that doesn't exist
 - Passing incorrect arguments to a field
-- Violating schema constraints, such as non-nullability
-- Runtime errors during execution
+- Omitting a selection set on a non-leaf field
+- Failure to specify the `operationName` when multiple operations exist in the request
 
 ### How to debug
 
@@ -114,18 +121,21 @@ validation errors differently. When in doubt, use error codes supported by the s
 
 ## Understanding GraphQL response formats
 
-Most GraphQL servers return responses using the `application/json` media type. However,
-the [GraphQL over HTTP spec](https://graphql.github.io/graphql-over-http/draft/) recommends 
-using a more specific type: `application/graphql-response+json`.
+Traditionally, GraphQL servers have returned responses using the `application/json` media type.
+However, the [GraphQL over HTTP spec](https://graphql.github.io/graphql-over-http/draft/) recommends 
+that clients request (and servers respond with) a more specific type: `application/graphql-response+json`.
 
-This media type identifies the payload as a GraphQL response and helps clients
-distinguish it from other types of JSON.
+This newer media type identifies the payload as a GraphQL response and helps clients
+distinguish it from other types of JSON, making the response safe to process even if
+it uses a non-2xx status code. A trusted proxy, gateway, or other intermediary
+might describe an error using JSON, but would never do so using `application/graphql-response+json`
+unless it was a valid GraphQL response.
 
 ### What to know
 
-- Servers may respond with `application/graphql-response+json` instead of
+- Servers may respond with `application/graphql-response+json` or
 `application/json`.
-- Clients can request this media type using the `Accept` header: `Accept: application/graphql-response+json`
-- This content type is optional, but support for it is growing.
+- Clients can request this media type using the `Accept` header: `Accept: application/graphql-response+json, application/json;q=0.9` (prefer the new media type over the old one, but accept both)
+- This content type is recommended, and support for it is growing.
 - If your client uses content negotiation, ensure your server can response with the appropriate
 type or fallback to `application/json`.

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -4,11 +4,9 @@ When building or consuming a GraphQL API over HTTP, it's common to run into
 errors, especially during development. Understanding how to recognize and resolve these issues
 can save you time and frustration.
 
-This guide outlines common `graphql-http` errors, what they mean, and how to debug them 
-effectively. These examples assume you're using the 
-[GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/draft/)
-and an implementation such as [`graphql-http`](https://github.com/graphql/graphql-http) or any 
-server that follows the spec.
+This guide outlines common errors, what they mean, and how to debug them 
+effectively. These examples relate to servers that implement the 
+[GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/draft/). Different servers may produce different error messages and status codes in some circumstances, so this document should be treated as a general guide rather than a canonical reference.
 
 ## `400 Bad Request`: Syntax or parse errors
 

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -107,7 +107,7 @@ Something went wrong on the server.
 
 ### What it means
 
-The HTTP layer succeeded, but the GraphQL response contains errors.
+The HTTP layer succeeded, but the GraphQL request produced errors.
 
 ### Common causes
 

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -4,9 +4,12 @@ When building or consuming a GraphQL API over HTTP, it's common to run into
 errors, especially during development. Understanding how to recognize and resolve these issues
 can save you time and frustration.
 
-This guide outlines common errors, what they mean, and how to debug them 
-effectively. These examples relate to servers that implement the 
-[GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/draft/). Different servers may produce different error messages and status codes in some circumstances, so this document should be treated as a general guide rather than a canonical reference.
+This guide outlines common HTTP and GraphQL errors, what they mean, and how to debug them 
+effectively. It follows the recommendations of the
+[GraphQL over HTTP spec (draft)](https://graphql.github.io/graphql-over-http/draft/),
+which standardizes how GraphQL works over HTTP, including request formats, status codes,
+and media types. Keep in mind that implementations may vary, so treat this as a general guide rather
+than a definitive reference.
 
 ## `400 Bad Request`: Syntax or parse errors
 
@@ -25,7 +28,7 @@ or the JSON body isn't valid.
 
 - Validate your JSON body using a linter or formatter.
 - Make sure you're sending a `POST` request with a `Content-Type: application/json` header.
-- Verify that the GraphQL query is syntactically correct. Use an IDE or a linter to verify it.
+- Check your GraphQL query for syntax errors. Use an IDE or linter to verify it.
 
 ## `405 Method Not Allowed`: Wrong HTTP Method
 
@@ -105,7 +108,7 @@ Something went wrong on the server.
 
 ### What it means
 
-The HTTP layer succeeded, but the GraphQL request produced errors.
+The HTTP layer succeeded, but the GraphQL operation produced errors.
 
 ### Common causes
 
@@ -116,11 +119,11 @@ The HTTP layer succeeded, but the GraphQL request produced errors.
 
 ### How to debug
 
-Check the `errors` array in the response body.
+Check the `errors` array in the response body. If the response includes a `data` property, then 
+your query document is likely valid and you most likely hit a runtime exception - perhaps due to
+invalid input, access denial, or a bug in server logic.
 
-If the response includes a `data` property then your query document is likely valid and you most likely hit a runtime exception - perhaps something went wrong on the server, you supplied invalid data, you're not allowed to do that, or some other runtime exception occurred.
-
-If the response does not include a `data` property it's likely there was a mistake in your request - an invalid GraphQL document or bad values for variables. A typical validation error response looks like:
+If there's no `data` field, the request likely failed during validation. For example:
 
 ```json
 {
@@ -133,4 +136,22 @@ If the response does not include a `data` property it's likely there was a mista
 }
 ```
 
-Compare your query against the schema using introspection or an IDE.
+Use introspection or an IDE to verify your query matches the schema.
+
+## Understanding GraphQL response formats
+
+Most GraphQL servers return responses using the `application/json` media type. However,
+the [GraphQL over HTTP spec](https://graphql.github.io/graphql-over-http/draft/) recommends 
+using a more specific type: `application/graphql-response+json`.
+
+This media type identifies the payload as a GraphQL response and helps clients
+distinguish it from other types of JSON.
+
+### What to know
+
+- Servers may respond with `application/graphql-response+json` instead of
+`application/json`.
+- Clients can request this media type using the `Accept` header: `Accept: application/graphql-response+json`
+- This content type is optional, but support for it is growing.
+- If your client uses content negotiation, ensure your server can response with the appropriate
+type or fallback to `application/json`.

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -16,7 +16,7 @@ than a definitive reference.
 ### What it means
 
 The server couldn't parse your request. Either the GraphQL query string is malformed,
-or the JSON body isn't valid.
+or the JSON body isn't valid. This is the primary error status recommended by the GraphQL over HTTP specification.
 
 ### Common causes
 
@@ -48,44 +48,6 @@ and may allow `GET` for queries.
 - Make sure your server supports `GET` for queries.
 - Refer to the [GraphQL over HTTP spec](https://graphql.github.io/graphql-over-http/draft/) to 
 confirm method support.
-
-## `415 Unsupported Media Type`
-
-### What it means
-
-The server doesn't understand the request's `Content-Type`.
-
-### Common causes
-
-- Sending a GraphQL query with `Content-Type: text/plain` or another unsupported type
-- Omitting the `Content-Type` header in a `POST` request
-
-### How to debug
-
-- Set the header explicitly: `Content-Type: application/json`.
-- If you're using `application/graphql`, verify your server supports it. This content type
-is optional.
-
-## `422 Unprocessable Entity`: Missing or invalid `query`
-
-### What it means
-
-The server received the request, but the `query` field was missing or invalid.
-
-### Common causes
-
-- Sending `{}` with no `query` key
-- Sending variables or an operation name without a query
-
-### How to debug
-
-Always include a `query` field in your request body. For example:
-
-```json
-{
-  "query": "{ user(id: 1) { name } }"
-}
-```
 
 ## `500 Internal Server Error`: Unexpected server failures
 
@@ -137,6 +99,18 @@ If there's no `data` field, the request likely failed during validation. For exa
 ```
 
 Use introspection or an IDE to verify your query matches the schema.
+
+## Implementation-specific status codes
+
+Some GraphQL server implementations may use additional HTTP status codes that are not explicitly recommended 
+by the specification. These vary by implementation.
+
+- `415 Unsupported Media Type`: The server doesn't understand the request's `Content-Type`. This can occur
+when a GraphQL query is sent with `Content-Type: text/plain` or another unsupported type. 
+- `422 Unprocessable Entity`: Some implementations use this for GraphQL validation errors instead of `200` + errors array.
+
+These error codes are not recommended by the specification for most cases. Different GraphQL servers handle 
+validation errors differently. When in doubt, use error codes supported by the specification.
 
 ## Understanding GraphQL response formats
 

--- a/src/pages/learn/debug-errors.mdx
+++ b/src/pages/learn/debug-errors.mdx
@@ -121,7 +121,6 @@ Check the `errors` array in the response body. A typical response looks like:
 
 ```json
 {
-  "data": null,
   "errors": [
     {
       "message": "Cannot query field \"foo\" on type \"Query\".",


### PR DESCRIPTION
## Description
- Adds guide on `graphql-http` errors (just some common ones) and how to debug them
- Adds block on Best Practices landing page

Feel free to suggest additional common errors if there are any that might be important to highlight here! 
