### PR TITLE
Remove "PDT" from hours

### DIFF
--- a/src/app/conf/2025/schedule/_components/schedule-list.tsx
+++ b/src/app/conf/2025/schedule/_components/schedule-list.tsx
@@ -199,7 +199,13 @@ export function ScheduleList({
                       <div className="mr-px flex flex-col max-lg:ml-px lg:flex-row">
                         <div className="relative border-neu-50 bg-neu-50 dark:bg-neu-0 max-lg:-mx-px max-lg:my-px max-lg:border-x lg:mr-px">
                           <span className="typography-body-sm mt-3 inline-block w-20 whitespace-nowrap pb-0.5 pl-4 lg:mr-6 lg:w-28 lg:pb-4 lg:pl-0">
-                            {format(parseISO(sessionDate), "hh:mmaaaa 'PDT'")}
+                            {parseISO(sessionDate).toLocaleTimeString(
+                              undefined,
+                              {
+                                hour: "2-digit",
+                                minute: "2-digit",
+                              },
+                            )}
                           </span>
                         </div>
                         <div className="relative flex w-full flex-col items-end gap-px lg:flex-row lg:items-start">

--- a/src/app/conf/_components/schedule/schedule-list.tsx
+++ b/src/app/conf/_components/schedule/schedule-list.tsx
@@ -172,7 +172,13 @@ export function ScheduleList({
                       <div className="mb-4 flex flex-col lg:flex-row">
                         <div className="relative">
                           <span className="mb-5 mt-3 inline-block w-20 whitespace-nowrap text-gray-500 lg:mr-7 lg:mt-0 lg:w-28">
-                            {format(parseISO(sessionDate), "hh:mmaaaa 'PDT'")}
+                            {parseISO(sessionDate).toLocaleTimeString(
+                              undefined,
+                              {
+                                hour: "2-digit",
+                                minute: "2-digit",
+                              },
+                            )}
                           </span>
                           <div className="absolute right-3 top-0 hidden h-full w-0.5 bg-gray-200 lg:block" />
                         </div>


### PR DESCRIPTION
## Description

Removed the time zone added from hour strings in Schedule.
Sched gives us a "venue-local" time, no time zone, just date, hour and minutes, like `2025-06-17 15:26`.

We have "AM" on designs, so I use browser locale to format it.