### PR TITLE
Switch the sponsors section layout to grid

### DIFF
--- a/src/app/conf/2025/components/sponsors.tsx
+++ b/src/app/conf/2025/components/sponsors.tsx
@@ -118,7 +118,7 @@ export function Sponsors({ heading }: SponsorsProps) {
               <Tier
                 key={tier.name}
                 tier={tier}
-                logoHeight={220 - sponsorTiers.indexOf(tier) * 24}
+                logoHeight={236 - sponsorTiers.indexOf(tier) * 32}
               />
             ),
         )}
@@ -134,7 +134,7 @@ function Tier({ tier, logoHeight }: { tier: Tier; logoHeight: number }) {
         <ChevronRight className="shrink-0 translate-y-[-0.5px]" />
         {tier.name}
       </h3>
-      <div className="flex min-w-[70%] flex-wrap justify-center gap-y-4">
+      <div className="flex min-w-[70%] flex-wrap justify-center gap-y-4 lg:grid lg:w-full lg:grid-cols-2 lg:gap-4">
         {tier.items.map(({ link, icon: Icon, name }, i) => (
           <a
             key={i}


### PR DESCRIPTION
## Description

Currently, the third logo in a tier is centered so it visually takes more space. This makes them more even (though still not perfectly even as the pictures themselves differ).

<img width="1412" height="783" alt="image" src="https://github.com/user-attachments/assets/d565fc1e-e4a5-4ee1-95ce-a78bbc3420a4" />

