### PR TITLE
GraphQLConf 2025 — Stop aligning text in What to Expect

### DIFF
--- a/src/app/conf/2025/components/what-to-expect.tsx
+++ b/src/app/conf/2025/components/what-to-expect.tsx
@@ -28,10 +28,10 @@ export default function WhatToExpectSection({
 function ListItem({ number, text }: { number: string | number; text: string }) {
   return (
     <li className="list-none bg-gradient-to-r from-[#CDF27E] p-6 dark:from-[#507501]">
-      <span className="inline-block w-[87px] text-[72px]/none [text-box:trim-both_cap_alphabetic]">
+      <span className="inline-block text-[72px]/none [text-box:trim-both_cap_alphabetic]">
         {number}
       </span>{" "}
-      <span className="typography-menu ml-10 inline-block">{text}</span>
+      <span className="typography-menu mb-2 inline-block">{text}</span>
     </li>
   )
 }


### PR DESCRIPTION
## Description

The original design didn't assume we'll have a triple digit number of sessions.
It doesn't make sense to align the texts now as the last blocks will have too much spacing between them and the numbers.

### Before

<img width="1401" height="593" alt="image" src="https://github.com/user-attachments/assets/37faeca6-8d44-481c-a7a0-c5ee83e59aff" />

### After

<img width="1451" height="602" alt="image" src="https://github.com/user-attachments/assets/28f0406c-14e7-418c-8d04-778bf644d8e7" />
