### PR TITLE
Remove unpaginated fields from connection-style pagination schema example

### DIFF
--- a/src/pages/learn/pagination.mdx
+++ b/src/pages/learn/pagination.mdx
@@ -113,7 +113,6 @@ To see this in action, there's an additional field in the example schema, called
 interface Character {
   id: ID!
   name: String!
-  friends: [Character]
   friendsConnection(first: Int, after: ID): FriendsConnection!
   appearsIn: [Episode]!
 }
@@ -121,7 +120,6 @@ interface Character {
 type FriendsConnection {
   totalCount: Int
   edges: [FriendsEdge]
-  friends: [Character]
   pageInfo: PageInfo!
 }
 


### PR DESCRIPTION
Closes #2099

## Description

I believe both of these fields are implying un-paginated access to the friends list. Likely you wouldn't want this exposed at all if you're trying to expose an paginated API, so I removed them from the examples. Not sure if this is the original intention or not, but seemed reasonable to me?
