### PR TITLE
Display times in schedule always in 24h format

### DIFF
--- a/src/app/conf/2025/schedule/_components/format-block-time.tsx
+++ b/src/app/conf/2025/schedule/_components/format-block-time.tsx
@@ -3,7 +3,7 @@ import { parseISO } from "date-fns"
 const timeFormat = new Intl.DateTimeFormat(undefined, {
   hour: "2-digit",
   minute: "2-digit",
-  hour12: false,
+  hour12: false, // per Carolyn's request
 })
 export const formatBlockTime = (start: string, end?: Date) => {
   const startDate = parseISO(start)

--- a/src/app/conf/2025/schedule/_components/format-block-time.tsx
+++ b/src/app/conf/2025/schedule/_components/format-block-time.tsx
@@ -3,6 +3,7 @@ import { parseISO } from "date-fns"
 const timeFormat = new Intl.DateTimeFormat(undefined, {
   hour: "2-digit",
   minute: "2-digit",
+  hour12: false,
 })
 export const formatBlockTime = (start: string, end?: Date) => {
   const startDate = parseISO(start)


### PR DESCRIPTION
## Description

We'll now display time in 24h format even if user's locale defaults to am/pm format.

<img width="1314" height="737" alt="image" src="https://github.com/user-attachments/assets/1f572ac2-8b06-48f2-a2cc-3e7ca2ec5fd7" />
