### PR TITLE
fix blog links

### DIFF
--- a/src/_design-system/mdx-components/mdx-link.tsx
+++ b/src/_design-system/mdx-components/mdx-link.tsx
@@ -12,7 +12,7 @@ export const MdxLink = forwardRef<
       {...props}
       ref={ref}
       className={clsx(
-        "typography-link text-neu-900 decoration-from-font underline-offset-2",
+        "typography-link text-neu-900 underline-offset-2",
         props.className,
       )}
       href={props.href || ""}

--- a/src/nextra-theme-docs.css
+++ b/src/nextra-theme-docs.css
@@ -1867,12 +1867,6 @@ article.nextra-body-typesetting-article h1 {
 article.nextra-body-typesetting-article h2 {
   border-style: none;
 }
-article.nextra-body-typesetting-article a {
-  text-decoration-line: none;
-}
-article.nextra-body-typesetting-article a:hover {
-  text-decoration-line: underline;
-}
 article.nextra-body-typesetting-article p {
   line-height: 2rem;
 }


### PR DESCRIPTION
## Description

I forgot nextra-theme-docs has a global style removing underlines from links in the “article” layout 😓, so when we moved the style of links in Learn to neutral color underlined, all links in blog started looking like ordinary text -.-

### Before

<img width="400" height="523" alt="image" src="https://github.com/user-attachments/assets/f0353605-f4bd-4f99-a1dd-a431c36faebe" />
<img width="400" height="619" alt="image" src="https://github.com/user-attachments/assets/6f0a7490-d304-4284-8515-de3f0185b47e" />

### After

<img width="400" height="713" alt="image" src="https://github.com/user-attachments/assets/812ba01c-550f-4aa9-8321-16287a0c5211" />


