### PR TITLE
Tweak the wording in the graphql.org blog post

### DIFF
--- a/src/pages/blog/2025-09-08-announcing-graphqldotorg.md
+++ b/src/pages/blog/2025-09-08-announcing-graphqldotorg.md
@@ -33,7 +33,7 @@ Beyond the visual refresh, this redesign showcases some interesting technical de
 
 **Creative Problem-Solving:** That smooth rotation animation you'll see? It's not just for aesthetics. [It's actually the only way to animate the element without breaking the highlight effects](https://stackoverflow.com/questions/74085350/backdrop-filter-doesnt-apply-if-parents-opacity-is-less-than-1) from the underlying wire graphics. Sometimes constraints lead to the most elegant solutions.
 
-**Developer Experience:** We discovered it's faster to iterate on syntax highlighting themes in VSCode than in our Nextra-shiki setup. This led us to accidentally[ create an entirely new custom syntax highlighting theme](https://github.com/hasparus/k-colorable) as a side effect of the redesign process.
+**Developer Experience:** We discovered it's faster to iterate on syntax highlighting themes in VSCode than in our Nextra-shiki setup. This led us to publish a [ syntax highlighting theme](https://github.com/hasparus/k-colorable) as a side effect of the redesign process.
 
 ## Explore the New Experience
 

--- a/src/pages/blog/2025-09-08-announcing-graphqldotorg.md
+++ b/src/pages/blog/2025-09-08-announcing-graphqldotorg.md
@@ -33,7 +33,7 @@ Beyond the visual refresh, this redesign showcases some interesting technical de
 
 **Creative Problem-Solving:** That smooth rotation animation you'll see? It's not just for aesthetics. [It's actually the only way to animate the element without breaking the highlight effects](https://stackoverflow.com/questions/74085350/backdrop-filter-doesnt-apply-if-parents-opacity-is-less-than-1) from the underlying wire graphics. Sometimes constraints lead to the most elegant solutions.
 
-**Developer Experience:** We discovered it's faster to iterate on syntax highlighting themes in VSCode than in our Nextra-shiki setup. This led us to publish a [ syntax highlighting theme](https://github.com/hasparus/k-colorable) as a side effect of the redesign process.
+**Developer Experience:** We discovered it's faster to iterate on syntax highlighting themes in VSCode than in our Nextra-shiki setup. This led us to publish a [syntax highlighting theme](https://github.com/hasparus/k-colorable) as a side effect of the redesign process.
 
 ## Explore the New Experience
 

--- a/src/pages/blog/2025-09-08-announcing-graphqldotorg.md
+++ b/src/pages/blog/2025-09-08-announcing-graphqldotorg.md
@@ -1,6 +1,6 @@
 ---
 title: "Introducing the New GraphQL.org: A Decade of Evolution, Redesigned"
-tags: ["announcement"]
+tags: ["announcements"]
 date: 2025-09-08
 byline: Saihajpreet Singh & Piotr Monwid-Olechnowicz
 ---


### PR DESCRIPTION
TLDR: Removed "entirely new" from the blog post.

## Description

I'm sorry, when I was reading the post before, it didn't strike me, but when I think about it now, I think we should rephrase a bit.

As you can see in its repo description (gib me a star pls :P), the theme is based on Min Light and GitHub Dark (both MIT licensed), and the parts of them that appear only in the editor, not on the website (e.g. editor controls) are _mostly_ unchanged.

I also removed the word "accidentally" because we didn't _plan_ to do it initially, it's not like an AI agent wrote `vsce publish`. I did it because after creating the theme to match designs and testing the code snippets we have in these docs, calling `vsce publish` was basically free.