### PR TITLE
Use playwright CLI directly from `./node_modules/.bin`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,10 +44,10 @@ jobs:
         # since the amount of time it takes to restore the cache is
         # comparable to the time it takes to download the binaries"
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: ./node_modules/.bin/playwright install --with-deps
 
       - name: Run Playwright tests
-        run: npx playwright test
+        run: ./node_modules/.bin/playwright test
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Description

I was just copying the yaml to another project and noticed that we have `npx` despite the fact that the project is using `pnpm`.

Using `pnpm playwright` and `pnpx playwright` actually makes it slower, but accessing Playwright's CLI directly is a small, but noticeable speedup.

This file is rarely read by a human and executed often on the CI, so I think we can take this trade-off and make it a bit uglier but faster to run.

### `time $1`

```
npx playwright -h > /dev/null  0.53s user 0.18s system 92% cpu 0.768 total

./node_modules/.bin/playwright -h  0.34s user 0.08s system 106% cpu 0.395 total
```
