### PR TITLE
2025 video pages: replace youtube embed link

### DIFF
--- a/src/app/conf/2025/speakers/[id]/long-session-card.tsx
+++ b/src/app/conf/2025/speakers/[id]/long-session-card.tsx
@@ -121,7 +121,7 @@ export function LongSessionCard({
       {video ? (
         <footer className="p-4 pt-0 lg:px-6 lg:pb-6">
           <Button
-            href={`https://youtube.com/embed/${video.id}`}
+            href={`/conf/${year}/schedule/${session.id}?name=${session.name}`}
             variant="primary"
             className="relative z-[2] w-full"
           >


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->



## Description

On a speaker's profile page, replaces YouTube embed link on the "watch" button with the correct link to view the video on its page with all the surrounding context, mirroring behaviour from the 2024 site.  