### PR TITLE
2025 conf pages: Stop downloads on render

### DIFF
--- a/src/app/conf/2025/schedule/[id]/page.tsx
+++ b/src/app/conf/2025/schedule/[id]/page.tsx
@@ -127,10 +127,12 @@ export default function SessionPage({ params }: SessionProps) {
                     <ul className="flex max-w-full flex-col gap-y-2">
                       {session.files?.map(({ path, name }) => (
                         <li key={path}>
-                          <iframe
-                            src={path}
-                            className="aspect-video size-full"
-                          />
+                          {path.endsWith(".pdf") && canRenderPdf() ? (
+                            <iframe
+                              src={path}
+                              className="aspect-video size-full"
+                            />
+                          ) : null}
                           <div className="flex items-stretch justify-between overflow-hidden">
                             <a
                               className="typography-link flex items-center truncate p-3 leading-none text-neu-700 max-xs:hidden sm:px-6"
@@ -294,4 +296,10 @@ function SessionDescription({ session }: { session: ScheduleSession }) {
       />
     </div>
   )
+}
+
+const isFirefox = navigator.userAgent.toLowerCase().includes("firefox")
+
+function canRenderPdf() {
+  return !isFirefox && !!navigator?.mimeTypes?.["application/pdf" as any]
 }


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

When navigating to a talk page in firefox, this triggered a download of the pdf or ppt file without pressing the download button, as firefox could not render the file in the iframe

This behaviour also exists in chrome for files other than a pdf

Fixed with a check to see if the file is a pdf and can be rendered, otherwise the iframe is removed. 
