### PR TITLE
Tidy markdown

### DIFF
--- a/src/pages/blog/2025-09-08-september-edition.md
+++ b/src/pages/blog/2025-09-08-september-edition.md
@@ -5,14 +5,14 @@ date: 2025-09-08
 byline: Lee Byron
 ---
 
-It’s here: the[ September 2025 edition of the GraphQL specification](https://spec.graphql.org/September2025/)!
+It’s here: the [September 2025 edition of the GraphQL specification](https://spec.graphql.org/September2025/)!
 
-This is the first edition of the specification since[ October 2021](https://spec.graphql.org/October2021/), and it reflects years of steady, collaborative work from the GraphQL community. More than 100 commits, hundreds of comments, and contributions from dozens of community members went into this update — all with the goal of keeping GraphQL stable, expressive, and primed for the next generation of AI-ready API development.
+This is the first edition of the specification since [October 2021](https://spec.graphql.org/October2021/), and it reflects years of steady, collaborative work from the GraphQL community. More than 100 commits, hundreds of comments, and contributions from dozens of community members went into this update — all with the goal of keeping GraphQL stable, expressive, and primed for the next generation of AI-ready API development.
 
 Since its initial release 10 years ago, GraphQL has grown into a critical layer of infrastructure at startups, enterprises, and platforms across industries. The spec has two guiding priorities:
 
-**Stability first**: With so many tools and services built on GraphQL, the ecosystem relies on a solid foundation. This release fixes inconsistencies, addresses edge cases, and helps avoid performance pitfalls. \
- \
+**Stability first**: With so many tools and services built on GraphQL, the ecosystem relies on a solid foundation. This release fixes inconsistencies, addresses edge cases, and helps avoid performance pitfalls.
+
 **Expressiveness for API consumers**: Developers use GraphQL because it’s intuitive, flexible, and powerful. This edition makes the language even more productive and expressive, particularly for AI-first applications.
 
 ## **Why It Matters**
@@ -27,20 +27,15 @@ Several updates in this edition make GraphQL an even better foundation for AI as
 ## **Notable Updates**
 
 - **OneOf Input Objects (a.k.a. input unions)** \
-  A long-requested feature! This unlocks more natural ways to model mutually exclusive inputs, leading to tidier schemas and unlocking use-cases that couldn’t be safely expressed previously - check out the [blog post](https://graphql.org/blog/2025-09-04-multioption-inputs-with-oneof/).[ RFC #825 \
-  ](https://github.com/graphql/graphql-spec/pull/825)
+  A long-requested feature! This unlocks more natural ways to model mutually exclusive inputs, leading to tidier schemas and unlocking use-cases that couldn’t be safely expressed previously - check out the [blog post](https://graphql.org/blog/2025-09-04-multioption-inputs-with-oneof/). [RFC #825](https://github.com/graphql/graphql-spec/pull/825)
 - **Schema Coordinates** \
-  A standardized way to refer to parts of a schema, paving the way for better tooling, error reporting, and developer experience.[ RFC #794 \
-  ](https://github.com/graphql/graphql-spec/pull/794)
+  A standardized way to refer to parts of a schema, paving the way for better tooling, error reporting, and developer experience. [RFC #794](https://github.com/graphql/graphql-spec/pull/794)
 - **Descriptions on Documents** \
-  Improved support for documenting queries and operations — helpful for humans and increasingly relevant for AI-powered tools.[ RFC #1170 \
-  ](https://github.com/graphql/graphql-spec/pull/1170)
+  Improved support for documenting queries and operations — helpful for humans and increasingly relevant for AI-powered tools. [RFC #1170](https://github.com/graphql/graphql-spec/pull/1170)
 - **Expanded Deprecation Support** \
-  Deprecation is now more broadly supported across schema elements, making it easier to evolve APIs without breaking clients. [RFCs [#805](https://github.com/graphql/graphql-spec/pull/805), [#1040](https://github.com/graphql/graphql-spec/pull/1040), [#1053](https://github.com/graphql/graphql-spec/pull/1053), [#1142](https://github.com/graphql/graphql-spec/pull/1142)]
-
+  Deprecation is now more broadly supported across schema elements, making it easier to evolve APIs without breaking clients. \[RFCs [#805](https://github.com/graphql/graphql-spec/pull/805), [#1040](https://github.com/graphql/graphql-spec/pull/1040), [#1053](https://github.com/graphql/graphql-spec/pull/1053), [#1142](https://github.com/graphql/graphql-spec/pull/1142)\]
 - **Full Unicode Support** \
-  \*\*The language grammar now supports the entire Unicode range, improving internationalization and accessibility.[ RFC #849 \
-  ](https://github.com/graphql/graphql-spec/pull/849)
+  The language grammar now supports the entire Unicode range, improving internationalization and accessibility. [RFC #849](https://github.com/graphql/graphql-spec/pull/849)
 - **Editorial Improvements** \
   The spec is clearer, more consistent, and easier to contribute to. Ambiguities have been reduced, and the style guide has been modernized.
 
@@ -50,12 +45,12 @@ This edition wouldn’t exist without the dedication of the GraphQL community. D
 
 Special thanks to the many reviewers, implementers, and champions who shaped this release.
 
-You can explore the full list of contributors in the[ changelog](https://github.com/graphql/graphql-spec/blob/main/changelogs/September2025.md).
+You can explore the full list of contributors in the [changelog](https://github.com/graphql/graphql-spec/blob/main/changelogs/September2025.md).
 
 ## **Get involved**
 
-GraphQL is a living standard. If you’re building APIs, tooling, or clients, your voice matters in shaping its future. Anyone can join[ working group meetings](https://github.com/graphql/graphql-wg) and contribute proposals, reviews, or feedback.
+GraphQL is a living standard. If you’re building APIs, tooling, or clients, your voice matters in shaping its future. Anyone can join [working group meetings](https://github.com/graphql/graphql-wg) and contribute proposals, reviews, or feedback.
 
-📖 **Read the full spec:**[ GraphQL September 2025 Specification \
-](https://spec.graphql.org/September2025/) 🔎 **Review all changes:**[ Full changelog & diff \
-](https://github.com/graphql/graphql-spec/compare/October2021...f29fbcd2ab5af763fce7ad62896eb62465a669b3) 🤝 **Contribute:**[ How to get involved](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md)
+📖 **Read the full spec:** [GraphQL September 2025 Specification](https://spec.graphql.org/September2025/) \
+🔎 **Review all changes:** [Full changelog & diff](https://github.com/graphql/graphql-spec/compare/October2021...f29fbcd2ab5af763fce7ad62896eb62465a669b3) \
+🤝 **Contribute:** [How to get involved](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
Some of the links included prefixed/postfixed spaces and newlines; I've adjusted the markup to be cleaner.