### PR TITLE
Add "the" in AI WG title, fix calendar url

### DIFF
--- a/src/pages/blog/2025-10-14-announcing-ai-wg.mdx
+++ b/src/pages/blog/2025-10-14-announcing-ai-wg.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Announcing GraphQL AI Working Group"
+title: "Announcing the GraphQL AI Working Group"
 tags: ["announcements"]
 date: 2025-10-14
 byline: Jeff Auriemma and Kewei Qu
@@ -14,7 +14,7 @@ As AI adoption accelerates, developers are using GraphQL to power everything fro
 We anticipate that the group will propose spec improvements and extensions to benefit both human and AI consumers, and raise opportunities to coordinate across organizations to support interoperability and compatibility.
 
 
-**Our first meeting is coming up on October 23** - grab the calendar invite at [calendar.graphql.org](calendar.graphql.org)!
+**Our first meeting is coming up on October 23** - grab the calendar invite at [calendar.graphql.org](https://calendar.graphql.org)!
 To join, open [PR against the agenda](https://github.com/graphql/ai-wg/tree/main/agendas) and add yourself, then follow the prompts to sign the EasyCLA. 
 
 Like all GraphQL working groups, this one is **open to everyone**. Whether you’re building AI APIs, researching integrations, or just curious about the possibilities, you’re welcome to join. If you can't make it, you can always catch up via the [GraphQL Foundation Working Groups YouTube channel](https://www.youtube.com/@GraphQLFoundation).


### PR DESCRIPTION
Adds `https://` to `calendar.graphql.org`, also adds "the" to the title which feels more natural to me (feel free to reject that suggestion)
