### PR TITLE
Update locals wording

### DIFF
--- a/src/pages/community/foundation/local-initiative.mdx
+++ b/src/pages/community/foundation/local-initiative.mdx
@@ -33,14 +33,13 @@ Organizers of a Local must agree:
   **[GraphQL Code of Conduct](https://graphql.org/codeofconduct/)**.
 - Official communications will comply with the
   **[GraphQL Brand Guidelines](https://graphql.org/brand/)**.
-- The Local accepts **GraphQL TSC oversight**:
+- At least one
+  [GraphQL Technical Steering Committee (TSC)
+  member](https://github.com/graphql/graphql-wg/blob/main/GraphQL-TSC.md#tsc-members)
+  must be granted administrator access to the Local’s online platforms.
   - Provides continuity for group members should we lose contact with an
     organizer.
-  - At least one
-    [GraphQL Technical Steering Committee (TSC)
-    member](https://github.com/graphql/graphql-wg/blob/main/GraphQL-TSC.md#tsc-members)
-    must be granted administrator access to the Local’s online platforms. (If
-    you don't know any TSC members, one will be recommended when you apply.)
+  - If you don't know any TSC members, one will be recommended when you apply.
   - In the case of a serious Code of Conduct breach, the TSC may take
     appropriate actions.
 - The Local has 1 or more organizer from the area. (We're pretty flexible on the


### PR DESCRIPTION
Follow up to https://github.com/graphql/graphql.github.io/pull/2166. 

As a TSC member, I trust the locals to do whatever is best for GraphQL and I find this wording a bit strong. 

Opinion softly held, I just want to make sure omitting that part from https://github.com/graphql/graphql.github.io/pull/2184 was not an ...🥁  oversight!!!