### PR TITLE
Update 2025 conference information (#2193)

### DIFF
--- a/src/pages/community/foundation/graphql-conf.mdx
+++ b/src/pages/community/foundation/graphql-conf.mdx
@@ -8,11 +8,8 @@ By the community and for the community, GraphQLConf is a vendor-neutral event th
 
 ## 2025
 
-We're looking forward to [GraphQLConf 2025](/conf/2024) in Amsterdam,
-Netherlands on September 08-10, 2025.
-
-Join us by [registering](/conf/2025), consider [submitting a talk](/conf/2025),
-and help produce an incredible event by [sponsoring us](/conf/2025).
+- [Recorded Sessions](/conf/2025/schedule)
+- [Gallery](/conf/2025/gallery)
 
 ## 2024
 

--- a/vercel.json
+++ b/vercel.json
@@ -71,6 +71,16 @@
       "permanent": true
     },
     {
+      "source": "/conf/2025/gallery",
+      "destination": "https://www.flickr.com/photos/linuxfoundation/sets/72177720328905487/",
+      "permanent": true
+    },
+    {
+      "source": "/conf/2025/gallery/",
+      "destination": "https://www.flickr.com/photos/linuxfoundation/sets/72177720328905487/",
+      "permanent": true
+    },
+    {
       "source": "/conf/gallery",
       "destination": "https://www.graphql.org/conf/2024/gallery",
       "permanent": false


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #2193

## Description

Update list conference page so that it:
* No longer talks about the 2025 conference in future tense.
* Now only links to 2 different webpages (gallery and schedule)
  * This also removes a incorrect link that sends the user to a 2024 conference webpage in the 2025 conference section.
