### PR TITLE
Introduce Beeceptor to the GraphQL tools list

### DIFF
--- a/src/code/services/beeceptor.md
+++ b/src/code/services/beeceptor.md
@@ -1,5 +1,5 @@
 ---
 name: Beeceptor
-description: "[Beeceptor](https://beeceptor.com/graphql-mock-server/?utm_source=graphql_org) is a no-code, cloud-based platform that enables creating **GraphQL Mock Servers** directly from your SDL schema with type-safe APIs containing **AI-enhanced realistic data**. It doubles as an HTTP Debugging Proxy to inspect and selectively mock all API traffic (GraphQL, REST, SOAP)."
+description: "[Beeceptor](https://beeceptor.com/graphql-mock-server/?utm_source=graphql_org) is a no-code, cloud-based platform that enables creating **GraphQL Mock Servers** directly from your SDL schema with type-safe APIs containing **AI-enhanced realistic data**. It doubles as an HTTP Debugging Proxy to inspect and selectively mock all API traffic (GraphQL, REST, SOAP). "
 url: https://beeceptor.com/graphql-mock-server/?utm_source=graphql_org
 ---

--- a/src/code/services/beeceptor.md
+++ b/src/code/services/beeceptor.md
@@ -1,0 +1,5 @@
+---
+name: Beeceptor
+description: "[Beeceptor](https://beeceptor.com/graphql-mock-server/?utm_source=graphql_org) is a no-code, cloud-based platform that enables creating **GraphQL Mock Servers** directly from your SDL schema with type-safe APIs containing **AI-enhanced realistic data**. It doubles as an HTTP Debugging Proxy to inspect and selectively mock all API traffic (GraphQL, REST, SOAP)."
+url: https://beeceptor.com/graphql-mock-server/?utm_source=graphql_org
+---


### PR DESCRIPTION
## Description
This PR incorporates Beeceptor into the documentation.

We are adding this tool as a helpful option for developers seeking to implement service virtualization.

Beeceptor offers a no-code approach to setting up mock GraphQL servers directly from the Schema Definition Language (SDL).
Its features include support for stateful responses, mutations, and subscriptions which may assist teams in facilitating parallel development and enhancing their integration testing workflows.
<!-- Write a brief description of the changes introduced by this PR -->
Changes introduced:
- Added beeceptor.md under `src/code/services`: 

