### PR TITLE
Fix broken links used in graphql-hooks.md

### DIFF
--- a/src/code/language-support/javascript/client/graphql-hooks.md
+++ b/src/code/language-support/javascript/client/graphql-hooks.md
@@ -7,8 +7,8 @@ npm: graphql-hooks
 
 - 🥇 First-class hooks API
 - ⚖️ _Tiny_ bundle: only 7.6kB (2.8 gzipped)
-- 📄 Full SSR support: see [graphql-hooks-ssr](packages/graphql-hooks-ssr)
-- 🔌 Plugin Caching: see [graphql-hooks-memcache](packages/graphql-hooks-memcache)
+- 📄 Full SSR support: see [graphql-hooks-ssr](https://github.com/nearform/graphql-hooks/tree/master/packages/graphql-hooks-ssr)
+- 🔌 Plugin Caching: see [graphql-hooks-memcache](https://github.com/nearform/graphql-hooks/tree/master/packages/graphql-hooks-memcache)
 - 🔥 No more render props hell
 - ⏳ Handle loading and error states with ease
 


### PR DESCRIPTION
## Description

Previously, [tools-and-libraries](https://graphql.org/community/tools-and-libraries/) webpage graphql-hooks README section's relative links would resolve to:
* https://graphql.org/community/packages/graphql-hooks-ssr/
* https://graphql.org/community/packages/graphql-hooks-memcache/

Both of these are incorrect and would display a 404. `GraphQL-hooks` wants to link to its directories in its GitHub project.

Closes #1971