### PR TITLE
Update the application process for the Ambassadors program

### DIFF
--- a/src/pages/community/ambassadors/apply.mdx
+++ b/src/pages/community/ambassadors/apply.mdx
@@ -123,10 +123,13 @@ clarity around what and how we create a safe and collaborative environment. See
 
 ## Application Process
 
-Applications are open year-round and are received by a small panel of Foundation
-and TSC members. Once the Ambassadors program is fully up-and-running,
-Ambassadors will also have the option to review applications. The Ambassador
-term is a year long, Ambassadors who continue to meet the expectations will be
+Applications are open year-round. 
+
+They are reviewed by the TSC members, the existing ambassadors as well as a small 
+panel of Foundation members. The review happens as outlined in the table below. 
+Applications that do not get a decision in time are rolled over to the next cohort.
+
+The Ambassador term is a year long, Ambassadors who continue to meet the expectations will be
 invited to join again at the end of their term.
 
 Applications can be from the applicant themselves, or a nomination from another
@@ -134,9 +137,8 @@ community member.
 
 ### Important Dates
 
-| Applications Open | Year Round |
-| ----------------------------| ---------------| 
 | First Ambassador Cohort Announced | September 2025 |
+| ----------------------------| ---------------| 
 | Applications Reviewed      | November 2025 |
 | Second Ambassador Cohort Announced | December 2025 | 
 | Applications Reviewed | February 2026| 


### PR DESCRIPTION
I was under the impression that there were deadline to apply and didn't realize that the applications that do not get a decision in time are rolled over. I think this was mainly because I did not get the table header and I thought the "Application Openining" period was the first column:

<img width="556" height="254" alt="Screenshot 2025-11-06 at 13 06 53" src="https://github.com/user-attachments/assets/fef509e6-9cb2-47b6-af1b-7a10bedc7259" />

This is an attempt to clarify this. @benjie @jemgillam please feel free to edit as you see fit.