### PR TITLE
fix missing mobile menu in 404 page

### DIFF
--- a/patches/nextra-theme-docs.patch
+++ b/patches/nextra-theme-docs.patch
@@ -36,7 +36,7 @@ index 71f87bcd1dde49d7c19ad49fc098e715a76c5c10..a0b8143b6b7ef89513c2199b956f5f87
 +  flatDocsDirectories: Item[]
 +}
 diff --git a/dist/index.js b/dist/index.js
-index 56201641fd965dcc5ab7c5df53e444c41293c00e..71f4d353b5bd6c0fcab630330f578b5593f8596e 100644
+index 56201641fd965dcc5ab7c5df53e444c41293c00e..cb6682bf947351f5757f51b43ff85237f16f1096 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -100,10 +100,10 @@ IntersectionObserverContext.displayName = "IntersectionObserver";
@@ -125,3 +125,12 @@ index 56201641fd965dcc5ab7c5df53e444c41293c00e..71f4d353b5bd6c0fcab630330f578b55
          body
        ] })
      }
+@@ -2524,7 +2485,7 @@ function getComponents({
+   components
+ }) {
+   if (isRawLayout) {
+-    return { a: A, wrapper: DEFAULT_COMPONENTS.wrapper };
++    return { a: A, wrapper: components.wrapper };
+   }
+   const context = { index: 0 };
+   return __spreadValues(__spreadProps(__spreadValues({}, DEFAULT_COMPONENTS), {

--- a/patches/nextra.patch
+++ b/patches/nextra.patch
@@ -20,6 +20,22 @@ index 9d05118d3d10e746cd2c020785a0f34465bb8570..218107600d7efed1b5f9d49f0a696b16
    Playground,
    Popup,
    Pre,
+diff --git a/dist/client/hooks/use-fs-route.js b/dist/client/hooks/use-fs-route.js
+index 7948959d9c044d66e241864789454e0ea637c659..46e352a845c3776965f3f1957e5d93b946444a3a 100644
+--- a/dist/client/hooks/use-fs-route.js
++++ b/dist/client/hooks/use-fs-route.js
+@@ -1,9 +1,9 @@
+-import { useRouter } from "next/router";
++import { useRouter } from "next/compat/router";
+ import { useMemo } from "react";
+ import { DEFAULT_LOCALE, ERROR_ROUTES } from "../../constants.js";
+ const template = "https://nextra.site";
+ const useFSRoute = () => {
+-  const { locale = DEFAULT_LOCALE, asPath, route } = useRouter();
++  const { locale = DEFAULT_LOCALE, asPath, route } = useRouter() || {};
+   return useMemo(() => {
+     const clientRoute = ERROR_ROUTES.has(route) ? route : asPath;
+     const { pathname } = new URL(clientRoute, template);
 diff --git a/dist/client/normalize-pages.js b/dist/client/normalize-pages.js
 index 15afee0c1de26f47d781f423e5ec32e33ad925d3..fefd01736bd2b778df275bf50ac48384d5f63845 100644
 --- a/dist/client/normalize-pages.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ patchedDependencies:
     hash: fccadc7038719bcf9dc12a573655719edaf7ea8246bd144c660191d05b38c637
     path: patches/mermaid-isomorphic.patch
   nextra:
-    hash: 007f6fda5122c6f4de34daac1f8221aa57dbe7c97563f4f6144c5c5310b2b7c8
+    hash: a4cb9ca39251906b7635817067482091dda31729230807c156358a0561ce2bcb
     path: patches/nextra.patch
   nextra-theme-docs:
-    hash: c25310b4430bc971f964edfe5e79740a63ed5681f13d12cb8632955647b92228
+    hash: 2cafbb261163557a490b97bea35ce78a55af9ec0ae200e2545ad15543b1443e5
     path: patches/nextra-theme-docs.patch
 
 importers:
@@ -145,10 +145,10 @@ importers:
         version: 3.0.1(less-loader@12.3.0(less@4.4.1))(less@4.4.1)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       nextra:
         specifier: 3.3.1
-        version: 3.3.1(patch_hash=007f6fda5122c6f4de34daac1f8221aa57dbe7c97563f4f6144c5c5310b2b7c8)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 3.3.1(patch_hash=a4cb9ca39251906b7635817067482091dda31729230807c156358a0561ce2bcb)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: 3.3.1
-        version: 3.3.1(patch_hash=c25310b4430bc971f964edfe5e79740a63ed5681f13d12cb8632955647b92228)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.3.1(patch_hash=007f6fda5122c6f4de34daac1f8221aa57dbe7c97563f4f6144c5c5310b2b7c8)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.3.1(patch_hash=2cafbb261163557a490b97bea35ce78a55af9ec0ae200e2545ad15543b1443e5)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.3.1(patch_hash=a4cb9ca39251906b7635817067482091dda31729230807c156358a0561ce2bcb)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       numbro:
         specifier: 2.5.0
         version: 2.5.0
@@ -12209,7 +12209,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@3.3.1(patch_hash=c25310b4430bc971f964edfe5e79740a63ed5681f13d12cb8632955647b92228)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.3.1(patch_hash=007f6fda5122c6f4de34daac1f8221aa57dbe7c97563f4f6144c5c5310b2b7c8)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  nextra-theme-docs@3.3.1(patch_hash=2cafbb261163557a490b97bea35ce78a55af9ec0ae200e2545ad15543b1443e5)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.3.1(patch_hash=a4cb9ca39251906b7635817067482091dda31729230807c156358a0561ce2bcb)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
@@ -12217,13 +12217,13 @@ snapshots:
       flexsearch: 0.7.43
       next: 14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      nextra: 3.3.1(patch_hash=007f6fda5122c6f4de34daac1f8221aa57dbe7c97563f4f6144c5c5310b2b7c8)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      nextra: 3.3.1(patch_hash=a4cb9ca39251906b7635817067482091dda31729230807c156358a0561ce2bcb)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       scroll-into-view-if-needed: 3.1.0
       zod: 3.25.76
 
-  nextra@3.3.1(patch_hash=007f6fda5122c6f4de34daac1f8221aa57dbe7c97563f4f6144c5c5310b2b7c8)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+  nextra@3.3.1(patch_hash=a4cb9ca39251906b7635817067482091dda31729230807c156358a0561ce2bcb)(@types/react@18.3.26)(acorn@8.15.0)(next@14.2.33(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
       '@headlessui/react': 2.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -26,6 +26,7 @@ export default function MainLayout({
           toc={[]}
           docsDirectories={docsDirectories}
           fullDirectories={directories}
+          asPopover
         />
         <div className="isolate bg-neu-0 text-neu-900 antialiased">
           {children}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -4,8 +4,12 @@ import { ThemeProvider } from "next-themes"
 import { Footer } from "../../components/footer"
 import { NewFontsStyleTag } from "../fonts"
 import { Navbar } from "../../components/navbar/navbar"
-import { topLevelNavbarItems } from "../../components/navbar/top-level-items"
-import { MenuProvider } from "./menu-provider"
+import {
+  directories,
+  docsDirectories,
+  topLevelNavbarItems,
+} from "../../components/navbar/top-level-items"
+import { Sidebar } from "../../components/sidebar"
 
 export default function MainLayout({
   children,
@@ -16,13 +20,17 @@ export default function MainLayout({
     <>
       <NewFontsStyleTag />
       <ThemeProvider attribute="class">
-        <MenuProvider>
           <Navbar items={topLevelNavbarItems} />
+          <Sidebar
+            includePlaceholder={false}
+            toc={[]}
+            docsDirectories={docsDirectories}
+            fullDirectories={directories}
+          />
           <div className="isolate bg-neu-0 text-neu-900 antialiased">
             {children}
           </div>
           <Footer />
-        </MenuProvider>
       </ThemeProvider>
     </>
   )

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -20,17 +20,17 @@ export default function MainLayout({
     <>
       <NewFontsStyleTag />
       <ThemeProvider attribute="class">
-          <Navbar items={topLevelNavbarItems} />
-          <Sidebar
-            includePlaceholder={false}
-            toc={[]}
-            docsDirectories={docsDirectories}
-            fullDirectories={directories}
-          />
-          <div className="isolate bg-neu-0 text-neu-900 antialiased">
-            {children}
-          </div>
-          <Footer />
+        <Navbar items={topLevelNavbarItems} />
+        <Sidebar
+          includePlaceholder={false}
+          toc={[]}
+          docsDirectories={docsDirectories}
+          fullDirectories={directories}
+        />
+        <div className="isolate bg-neu-0 text-neu-900 antialiased">
+          {children}
+        </div>
+        <Footer />
       </ThemeProvider>
     </>
   )

--- a/src/app/(main)/menu-provider.tsx
+++ b/src/app/(main)/menu-provider.tsx
@@ -1,9 +1,0 @@
-"use client"
-import { MenuProvider as NextraMenuProvider } from "nextra-theme-docs"
-import { useMemo, useState } from "react"
-
-export function MenuProvider({ children }: { children: React.ReactNode }) {
-  const [menu, setMenu] = useState(false)
-  const value = useMemo(() => ({ menu, setMenu }), [menu])
-  return <NextraMenuProvider value={value}>{children}</NextraMenuProvider>
-}

--- a/src/app/conf/2025/components/register-today/index.tsx
+++ b/src/app/conf/2025/components/register-today/index.tsx
@@ -38,7 +38,7 @@ export function RegisterToday({ className }: RegisterTodayProps) {
         </div>
         <div className="mt-10 flex gap-x-6 gap-y-4 max-sm:flex-col">
           <Button disabled className="opacity-55" href={GET_TICKETS_LINK}>
-            Registeration closed
+            Registration closed
           </Button>
           <Button
             disabled

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -8,7 +8,6 @@ import NextLink from "next/link"
 import { Button } from "nextra/components"
 import type * as normalizePages from "nextra/normalize-pages"
 import React, { useEffect, type ReactElement, type ReactNode } from "react"
-import { useMenu } from "nextra-theme-docs"
 import { Anchor } from "@/app/conf/_design-system/anchor"
 
 import MenuIcon from "@/app/conf/_design-system/pixelarticons/menu.svg?svgr"
@@ -17,6 +16,7 @@ import { GraphQLWordmarkLogo } from "../../icons"
 import { ThemeSwitch } from "../theme-switch"
 import { Flexsearch } from "../flexsearch"
 import { NavLink, navLinkClasses } from "./nav-link"
+import { useMenu } from "../use-menu"
 
 type Item = normalizePages.PageItem | normalizePages.MenuItem
 export interface NavBarProps {

--- a/src/components/navbar/top-level-items.tsx
+++ b/src/components/navbar/top-level-items.tsx
@@ -47,4 +47,4 @@ export function normalizeMetaToItems(meta: Record<string, any>, parent = "/") {
   return result
 }
 
-export const { topLevelNavbarItems } = normalizeMetaToItems(meta)
+export const { topLevelNavbarItems, docsDirectories, directories } = normalizeMetaToItems(meta)

--- a/src/components/navbar/top-level-items.tsx
+++ b/src/components/navbar/top-level-items.tsx
@@ -47,4 +47,5 @@ export function normalizeMetaToItems(meta: Record<string, any>, parent = "/") {
   return result
 }
 
-export const { topLevelNavbarItems, docsDirectories, directories } = normalizeMetaToItems(meta)
+export const { topLevelNavbarItems, docsDirectories, directories } =
+  normalizeMetaToItems(meta)

--- a/src/components/nextra-mdx-wrapper.tsx
+++ b/src/components/nextra-mdx-wrapper.tsx
@@ -49,6 +49,7 @@ export function NextraMdxWrapper({
         <TableOfContents toc={toc} filePath={config.filePath} />
       </nav>
     )
+
   return (
     <div
       className={clsx(

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -415,7 +415,7 @@ export function Sidebar({
           "nextra-sidebar-container flex flex-col",
           "motion-reduce:transform-none motion-reduce:transition-none md:top-16 md:shrink-0",
           "[.resizing_&]:transition-none",
-          "transform-gpu transition-all ease-in-out",
+          "transition-gpu ease-in-out",
           "print:hidden",
           showSidebar ? "md:w-64" : "md:w-20",
           asPopover ? "md:hidden" : "md:sticky md:self-start",

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -52,8 +52,8 @@ const Folder = memo(function FolderInner(props: FolderProps) {
 
 const classes = {
   link: cn(
-    "_flex _px-2 _py-1.5 _text-sm _transition-colors [word-break:break-word]",
-    "_cursor-pointer contrast-more:border contrast-more:hover:underline gql-focus-visible focus-visible:outline-offset-1",
+    "flex px-2 py-1.5 text-sm transition-colors [word-break:break-word]",
+    "cursor-pointer contrast-more:border contrast-more:hover:underline gql-focus-visible focus-visible:outline-offset-1",
   ),
   inactive: cn(
     "text-neu-800 hover:bg-neu-100 hover:text-neu-900 hover:bg-neu-100 dark:hover:bg-neu-50/50",
@@ -61,13 +61,13 @@ const classes = {
   ),
   active: cn(
     "bg-pri-lighter/25 text-pri-dark dark:bg-pri-light/10 dark:text-pri-light",
-    "contrast-more:_border-primary-500 contrast-more:dark:_border-primary-500",
+    "contrast-more:border-primary-500 contrast-more:dark:border-primary-500",
   ),
-  list: cn("_flex _flex-col _gap-1"),
+  list: cn("flex flex-col gap-1"),
   border: cn(
-    "_relative before:_absolute before:_inset-y-1",
-    'before:_w-px before:bg-neu-100 before:_content-[""] dark:before:bg-neu-50',
-    "ltr:_pl-3 ltr:before:_left-0 rtl:_pr-3 rtl:before:_right-0",
+    "relative before:absolute before:inset-y-1",
+    'before:w-px before:bg-neu-100 before:content-[""] dark:before:bg-neu-50',
+    "pl-3 before:left-0",
   ),
 }
 
@@ -164,8 +164,8 @@ function FolderImpl({ item, anchors, onFocus }: FolderProps): ReactElement {
         }
         data-href={isLink ? undefined : item.route}
         className={cn(
-          "_items-center _justify-between _gap-2",
-          !isLink && "_text-left _w-full",
+          "items-center justify-between gap-2",
+          !isLink && "w-full text-left",
           classes.link,
           active ? classes.active : classes.inactive,
         )}
@@ -197,17 +197,16 @@ function FolderImpl({ item, anchors, onFocus }: FolderProps): ReactElement {
         <ArrowRightIcon
           height="18"
           className={cn(
-            "_shrink-0",
-            "_p-0.5 hover:bg-neu-100/5",
-            "motion-reduce:*:_transition-none *:_origin-center *:_transition-transform *:rtl:_-rotate-180",
-            open && "*:ltr:_rotate-90 *:rtl:_rotate-[-270deg]",
+            "shrink-0 p-0.5 hover:bg-neu-100/5",
+            "origin-center transition-transform motion-reduce:*:transition-none",
+            open && "rotate-90",
           )}
         />
       </ComponentToUse>
       {Array.isArray(item.children) && (
         <Collapse isOpen={open}>
           <Menu
-            className={cn(classes.border, "_pt-1 ltr:_ml-3 rtl:_mr-3")}
+            className={cn(classes.border, "ml-3 pt-1")}
             directories={item.children}
             base={item.route}
             anchors={anchors}
@@ -270,14 +269,14 @@ function File({
         {item.title}
       </Anchor>
       {active && anchors.length > 0 && (
-        <ul className={cn(classes.list, classes.border, "ltr:_ml-3 rtl:_mr-3")}>
+        <ul className={cn(classes.list, classes.border, "ml-3")}>
           {anchors.map(({ id, value }) => (
             <li key={id}>
               <a
                 href={`#${id}`}
                 className={cn(
                   classes.link,
-                  '_flex _gap-2 before:_opacity-25 before:_content-["#"]',
+                  'flex gap-2 before:opacity-25 before:content-["#"]',
                   activeAnchor[id]?.isActive
                     ? classes.active
                     : classes.inactive,
@@ -400,26 +399,26 @@ export function Sidebar({
   return (
     <>
       {includePlaceholder && asPopover && (
-        <div className="max-xl:_hidden _h-0 _w-64 _shrink-0" />
+        <div className="h-0 w-64 shrink-0 max-xl:hidden" />
       )}
       <div
         className={cn(
           "[transition:background-color_1.5s_ease]",
           menu
-            ? "max-md:_bg-black/80 max-md:dark:_bg-black/60 _fixed _inset-0 _z-10"
-            : "_bg-transparent",
+            ? "fixed inset-0 z-10 max-md:bg-black/80 max-md:dark:bg-black/60"
+            : "bg-transparent",
         )}
         onClick={() => setMenu(false)}
       />
       <aside
         className={cn(
-          "nextra-sidebar-container _flex _flex-col",
-          "md:_top-16 md:_shrink-0 motion-reduce:_transform-none motion-reduce:_transition-none",
-          "[.resizing_&]:_transition-none",
-          "_transform-gpu _transition-all _ease-in-out",
-          "print:_hidden",
-          showSidebar ? "md:_w-64" : "md:_w-20",
-          asPopover ? "md:_hidden" : "md:_sticky md:_self-start",
+          "nextra-sidebar-container flex flex-col",
+          "motion-reduce:transform-none motion-reduce:transition-none md:top-16 md:shrink-0",
+          "[.resizing_&]:transition-none",
+          "transform-gpu transition-all ease-in-out",
+          "print:hidden",
+          showSidebar ? "md:w-64" : "md:w-20",
+          asPopover ? "md:hidden" : "md:sticky md:self-start",
           menu
             ? "max-md:[transform:translate3d(0,0,0)]"
             : "max-md:[transform:translate3d(0,-100%,0)]",
@@ -436,8 +435,8 @@ export function Sidebar({
           <OnFocusItemContext.Provider value={setFocused}>
             <div
               className={cn(
-                "_overflow-y-auto",
-                "_p-4 _grow md:_h-[calc(100vh-var(--nextra-navbar-height)-var(--nextra-menu-height))]",
+                "overflow-y-auto",
+                "grow p-4 md:h-[calc(100vh-var(--nextra-navbar-height)-var(--nextra-menu-height))]",
                 showSidebar ? "nextra-scrollbar" : "no-scrollbar",
               )}
               ref={sidebarRef}
@@ -447,7 +446,7 @@ export function Sidebar({
                 <Collapse isOpen={showSidebar} horizontal>
                   <Menu
                     // eslint-disable-next-line tailwindcss/no-custom-classname
-                    className="nextra-menu-desktop max-md:_hidden"
+                    className="nextra-menu-desktop max-md:hidden"
                     // The sidebar menu, shows only the docs directories.
                     directories={docsDirectories}
                     // When the viewport size is larger than `md`, hide the anchors in
@@ -459,7 +458,7 @@ export function Sidebar({
               )}
               {mounted && window.innerWidth < 768 && (
                 <Menu
-                  className="nextra-menu-mobile md:_hidden"
+                  className="nextra-menu-mobile md:hidden"
                   // The mobile dropdown menu, shows all the directories.
                   directories={fullDirectories}
                   // Always show the anchor links on mobile (`md`).
@@ -509,7 +508,7 @@ export function SidebarFooter({
         className,
       )}
     >
-      <div className={showSidebar && !hasI18n ? "_grow _flex _flex-col" : ""}>
+      <div className={showSidebar && !hasI18n ? "flex grow flex-col" : ""}>
         <ThemeSwitch lite={!showSidebar} />
       </div>
       {themeConfig.sidebar.toggleButton && (

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -22,20 +22,15 @@ import {
   useState,
 } from "react"
 import scrollIntoView from "scroll-into-view-if-needed"
-import {
-  useActiveAnchor,
-  useMenu,
-  useThemeConfig,
-  Collapse,
-  LocaleSwitch,
-} from "nextra-theme-docs"
+import { useActiveAnchor, useThemeConfig, Collapse } from "nextra-theme-docs"
 
 import ArrowBarLeft from "@/app/conf/_design-system/pixelarticons/arrow-bar-left.svg?svgr"
 import { Anchor } from "@/app/conf/_design-system/anchor"
 
-import { renderComponent } from "./utils/render-component"
-import { ThemeSwitch } from "./theme-switch"
-import { Flexsearch } from "./flexsearch"
+import { renderComponent } from "../utils/render-component"
+import { ThemeSwitch } from "../theme-switch"
+import { Flexsearch } from "../flexsearch"
+import { useMenu } from "../use-menu"
 
 const TreeState: Record<string, boolean> = Object.create(null)
 
@@ -229,7 +224,7 @@ function Separator({ title }: { title: string }): ReactElement {
       className={cn(
         "[word-break:break-word]",
         title
-          ? "typography-body-sm mb-2 px-2 py-1.5 font-semibold text-neu-800 [&:not(:first-child)]:mt-5"
+          ? "typography-body-sm mb-2 px-2 py-1.5 font-semibold text-neu-800 max-md:first:hidden [&:not(:first-child)]:mt-5"
           : "my-4",
       )}
     >
@@ -370,7 +365,6 @@ export function Sidebar({
   const { menu, setMenu } = useMenu()
   const [focused, setFocused] = useState("")
   const [showSidebar, setSidebar] = useState(true)
-  const [showToggleAnimation, setToggleAnimation] = useState(false)
 
   const anchors = useMemo(() => toc.filter(v => v.depth === 2), [toc])
   const sidebarRef = useRef<HTMLDivElement>(null!)
@@ -480,7 +474,6 @@ export function Sidebar({
           <SidebarFooter
             showSidebar={showSidebar}
             setSidebar={setSidebar}
-            showToggleAnimation={showToggleAnimation}
             hasI18n={hasI18n}
           />
         )}
@@ -492,17 +485,13 @@ export function Sidebar({
 export function SidebarFooter({
   showSidebar,
   setSidebar,
-  showToggleAnimation = false,
   hasI18n = false,
-  setToggleAnimation,
   className,
   hiddenOnMobile = true,
 }: {
   showSidebar: boolean
   setSidebar: (show: boolean) => void
-  showToggleAnimation?: boolean
   hasI18n?: boolean
-  setToggleAnimation?: (show: boolean) => void
   className?: string
   hiddenOnMobile?: boolean
 }) {
@@ -519,14 +508,7 @@ export function SidebarFooter({
           : "flex-col flex-wrap justify-center py-4",
         className,
       )}
-      data-toggle-animation={
-        showToggleAnimation ? (showSidebar ? "show" : "hide") : "off"
-      }
     >
-      <LocaleSwitch
-        lite={!showSidebar}
-        className={showSidebar ? "_grow" : "max-md:_grow"}
-      />
       <div className={showSidebar && !hasI18n ? "_grow _flex _flex-col" : ""}>
         <ThemeSwitch lite={!showSidebar} />
       </div>
@@ -539,7 +521,6 @@ export function SidebarFooter({
           )}
           onClick={() => {
             setSidebar(!showSidebar)
-            setToggleAnimation?.(true)
           }}
         >
           <ArrowBarLeft

--- a/src/components/tools-and-libraries.tsx
+++ b/src/components/tools-and-libraries.tsx
@@ -630,7 +630,7 @@ function ToolsAndLibrariesHeader({
   const { activePath } = useConfig().normalizePagesResult
 
   return (
-    <div className="top-[--navbar-h] z-[1] mt-2 flex items-center justify-between bg-[rgb(var(--nextra-bg),.8)] py-2 backdrop-blur-[6.4px] max-md:sticky">
+    <div className="top-[--navbar-h] z-[1] flex items-center justify-between bg-[rgb(var(--nextra-bg),.65)] py-2 backdrop-blur-[6.4px] [text-box:trim-both_cap_alphabetic] max-md:sticky max-md:mt-2 md:pt-0 md:leading-none">
       <div className="relative">
         <Breadcrumbs className="mb-2 mt-1 md:mb-6" activePath={activePath} />
         <RadioGroup

--- a/src/components/use-menu.tsx
+++ b/src/components/use-menu.tsx
@@ -1,0 +1,24 @@
+import { useSyncExternalStore } from "react"
+
+const createStore = () => {
+  let state = false
+  const listeners = new Set<() => void>()
+  return {
+    get: () => state,
+    sub: (l: () => void) => (listeners.add(l), () => listeners.delete(l)),
+    set: (action: boolean | ((prev: boolean) => boolean)) => {
+      const val = typeof action === "function" ? action(state) : action
+      if (val !== state) {
+        state = val
+        listeners.forEach(l => l())
+      }
+    },
+  }
+}
+
+const store = createStore()
+
+export const useMenu = () => ({
+  menu: useSyncExternalStore(store.sub, store.get, store.get),
+  setMenu: store.set,
+})

--- a/src/nextra-theme-docs.css
+++ b/src/nextra-theme-docs.css
@@ -2958,3 +2958,12 @@ kbd._border._gap-1 {
     color: hsl(var(--color-neu-500));
   }
 }
+
+:root {
+  --nextra-bg: 251, 251, 249;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --nextra-bg: 15, 15, 12;
+  }
+}

--- a/src/nextra-theme-docs.css
+++ b/src/nextra-theme-docs.css
@@ -2962,8 +2962,6 @@ kbd._border._gap-1 {
 :root {
   --nextra-bg: 251, 251, 249;
 }
-@media (prefers-color-scheme: dark) {
-  :root {
+.dark {
     --nextra-bg: 15, 15, 12;
-  }
 }

--- a/src/nextra-theme-docs.css
+++ b/src/nextra-theme-docs.css
@@ -2963,5 +2963,5 @@ kbd._border._gap-1 {
   --nextra-bg: 251, 251, 249;
 }
 .dark {
-    --nextra-bg: 15, 15, 12;
+  --nextra-bg: 15, 15, 12;
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,6 +8,8 @@ import "@/docs.css"
 import "@/globals.css"
 import "@/app/colors.css"
 
+import { useMenu } from "../components/use-menu"
+
 const gaId = process.env.NEXT_PUBLIC_GA_ID
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
@@ -17,13 +19,17 @@ function handleRouteChange(url: string) {
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter()
+
   useEffect(() => {
     if (!gaId) return
     router.events.on("routeChangeComplete", handleRouteChange)
     return () => {
       router.events.off("routeChangeComplete", handleRouteChange)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  const menu = useMenu()
 
   return (
     <>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -220,6 +220,7 @@ const config: Config = {
       })
     }),
     tailwindMediaHover(),
+    prefersContrastPlugin(),
     scrollStartPlugin(),
     scrollviewFadePlugin(),
     browserPlugin,
@@ -233,6 +234,12 @@ function tailwindMediaHover() {
   return plugin(({ addVariant }) => {
     addVariant("hover-hover", "@media (hover: hover)")
     addVariant("hover-none", "@media (hover: none)")
+  })
+}
+
+function prefersContrastPlugin() {
+  return plugin(({ addVariant }) => {
+    addVariant("contrast-more", "@media (prefers-contrast: more)")
   })
 }
 


### PR DESCRIPTION
## Description

- Removed MenuProvider wrapper and implement custom useMenu hook with useSyncExternalStore
- Added missing sidebar to main layout for 404 page
- Patched Nextra Theme Docs again to show the same sidebar and use the same layout wrapper in all pages in Pages router (previously Nextra used the default wrapper for layout=raw, so we had two subtly different sidebars)
- Fixed "Registeration" typo