### PR TITLE
Make "Start a GraphQL Local" link to /local-initiative page

### DIFF
--- a/src/app/(main)/community/events/bring-graphql-to-your-community.tsx
+++ b/src/app/(main)/community/events/bring-graphql-to-your-community.tsx
@@ -1,6 +1,5 @@
 import { Button } from "../../../conf/_design-system/button"
 import { StripesDecoration } from "../../../conf/_design-system/stripes-decoration"
-import { DISCORD_CHANNEL_LINK } from "./links"
 
 export function BringGraphQLToYourCommunity() {
   return (
@@ -26,7 +25,7 @@ export function BringGraphQLToYourCommunity() {
             Learn more
           </Button>
           <Button
-            href={DISCORD_CHANNEL_LINK}
+            href="/community/foundation/local-initiative/"
             variant="tertiary"
             className="[.light_&]:bg-white"
           >

--- a/src/pages/community/foundation/local-initiative.mdx
+++ b/src/pages/community/foundation/local-initiative.mdx
@@ -6,7 +6,7 @@ description:
   sustainability of our ecosystem.
 ---
 
-import { Button } from "../../../app/conf/_components/button"
+import { Button } from "../../../app/conf/_design-system/button"
 
 # GraphQL Local Initiative
 
@@ -177,7 +177,7 @@ gatherings. For more information or to get started, please contact us on
 
 <Button
   href="mailto:local@graphql.org?subject=I%20want%20to%20start%20a%20GraphQL%20Local%20in%20CITY_NAME_HERE"
-  className="mx-auto my-6 !block"
+  className="mx-auto my-6 w-fit"
 >
-  Start a GraphQL Local!
+  Start a GraphQL Local
 </Button>


### PR DESCRIPTION
Closes a comment from @jemgillam https://github.com/graphql/graphql.github.io/issues/2189#issuecomment-3511760696

## Description

I initially made it link straight to Discord but it makes more sense to link to `/local-initiative` page.