### PR TITLE
render hover halo over not under squares

### DIFF
--- a/src/app/(main)/community/events/map/shaders.ts
+++ b/src/app/(main)/community/events/map/shaders.ts
@@ -158,16 +158,9 @@ void main() {
   vec2 delta = abs(fragPx - center);
   bool insideSquare = delta.x <= squareHalf && delta.y <= squareHalf;
   bool isSeaCell = markerType <= 0.5 && landCoverage < 0.5;
-  bool shouldRenderHalo = !insideSquare || isSeaCell;
-  if (shouldRenderHalo) {
-    if (haloIntensity <= 0.0) {
-      discard;
-    }
-    float haloAlpha = clamp(haloIntensity, 0.0, 1.0);
-    color = mix(uSeaColor, uHaloColor, haloAlpha);
-    outColor = vec4(color, 1.0);
-    return;
-  }
+  float haloAlpha = clamp(haloIntensity, 0.0, 1.0);
+  color = (isSeaCell || !insideSquare) ? uSeaColor : color;
+  color = mix(color, uHaloColor, haloAlpha);
   outColor = vec4(color, 1.0);
 }
 `


### PR DESCRIPTION
## Description

I previously used `discard` to draw edges on the map instead of using sea color and I rendered the hover halo _below_ the squares. I woke up feeling bad about it so now the code is simpler and the hover effect is positioned how we'd expect it.

<img width="309" height="133" alt="image" src="https://github.com/user-attachments/assets/d2b521f9-6085-4666-a339-4e0c3493b97b" />