### PR TITLE
Show neaerest events first in upcoming events

### DIFF
--- a/src/app/(main)/community/events/page.tsx
+++ b/src/app/(main)/community/events/page.tsx
@@ -68,7 +68,7 @@ export default async function EventsPage() {
               Add a new event
             </Button>
           </header>
-          <EventsList events={upcomingEvents}>
+          <EventsList events={upcomingEvents.reverse()}>
             <SubscribeToRssLink />
           </EventsList>
           <Button className="md:hidden" href={ISSUE_TEMPLATE_LINK}>


### PR DESCRIPTION
## Description

Previously, upcoming events were sorted the in the same manner as past events, but we should show them in ascending order to show the nearest events first.