### PR TITLE
Unify font-size in Precision figure

### DIFF
--- a/src/components/index-page/graphql-advantages/precision.tsx
+++ b/src/components/index-page/graphql-advantages/precision.tsx
@@ -96,7 +96,7 @@ export function PrecisionFigure() {
       className="nextra-codeblocks flex w-full max-w-[100vw] bg-gradient-to-b from-transparent to-sec-lighter px-[14px] py-[30px] *:w-1/2 dark:to-sec-darker/25 max-[380px]:px-0 sm:max-w-[calc(100vw-32px)] xl:px-[46px] max-[380px]:[&_:is(.rounded-t-md,pre)]:rounded-none [&_pre]:!h-48"
       aria-hidden
     >
-      <Pre data-filename="Query" className="p-4 text-[#6E7557]">
+      <Pre data-filename="Query" className="p-4 text-sm text-[#6E7557]">
         {"{"}
         {"\n  "}
         <span className="!text-pri-base dark:!text-sec-light">{"hero"}</span>


### PR DESCRIPTION
## Description

I just noticed that the font-sizes in the Precision figure on the landing went out of sync. This fixes them so it's 14px on both sides.

<img width="687" height="329" alt="image" src="https://github.com/user-attachments/assets/c836e1ce-4dc2-4919-9a15-8b9b39b3eab4" />
<img width="626" height="291" alt="image" src="https://github.com/user-attachments/assets/595a22a1-2eaf-4d39-b48d-5933c8e1016e" />
