### PR TITLE
Fix typo in event announcement statement

### DIFF
--- a/src/pages/community/foundation/local-initiative.mdx
+++ b/src/pages/community/foundation/local-initiative.mdx
@@ -58,7 +58,7 @@ Organizers of a Local must agree:
   - Publishing to [@GraphQLFoundationTalks on
     YouTube](https://www.youtube.com/@GraphQLFoundationTalks) is possible - just
     ask!
-- Official events will be be **announced at least two weeks in advance**.
+- Official events will be **announced at least two weeks in advance**.
   Popular ticketing platforms include Eventbrite, Guild.host, and Meetup.com.
 - Attending official events will be **affordable**.
   - If not free, attendance fees must not exceed USD $10 or local equivalent


### PR DESCRIPTION
## Description

Fixes typo by removing a duplicate `be`
