### PR TITLE
Reduce internal layout jitter and make sidebar closing look better

### DIFF
--- a/src/components/collapse/index.tsx
+++ b/src/components/collapse/index.tsx
@@ -47,7 +47,7 @@ export function Collapse({
 
     if (isOpen) {
       if (horizontal) {
-        child.style.removeProperty("width")
+        child.style.removeProperty("minWidth")
         container.style.removeProperty("width")
       } else {
         container.style.height = `${child.clientHeight}px`
@@ -57,8 +57,9 @@ export function Collapse({
       }
     } else {
       if (horizontal) {
-        child.style.width = `${child.clientWidth}px`
-        container.style.width = `${child.clientWidth}px`
+        const width = child.clientWidth
+        child.style.minWidth = `${width}px`
+        container.style.width = `${width}px`
       } else {
         container.style.height = `${child.clientHeight}px`
       }

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -446,7 +446,7 @@ export function Sidebar({
           "nextra-sidebar-container flex flex-col",
           "motion-reduce:transform-none motion-reduce:transition-none md:top-16 md:shrink-0",
           "[.resizing_&]:transition-none",
-          "transition-gpu ease-in-out",
+          "transition-gpu duration-300 ease-in-out",
           "print:hidden",
           showSidebar ? "md:w-64" : "md:w-20",
           asPopover ? "md:hidden" : "md:sticky md:self-start",


### PR DESCRIPTION
## Description

This one is for the design engineers.

I changed the Collapse so the child items keep their width when the sidebar is closed and the text doesn't jump.



### Before

https://github.com/user-attachments/assets/c336956a-8a5c-46f0-a455-0244a7d35126

### After

https://github.com/user-attachments/assets/d27f7b55-9024-4152-8cb4-fc0d2de19272


