### PR TITLE
Filter out working groups by default

### DIFF
--- a/test/e2e/community-events.spec.ts
+++ b/test/e2e/community-events.spec.ts
@@ -219,7 +219,9 @@ test("event type filters hide cards and lock the last active tag", async ({
     const badgeLocator = tagBadge(definition.badgeText)
     if ((await definition.filter.count()) === 0) continue
     const filterDefinition = { ...definition, badges: badgeLocator }
-    activeFilters.push(filterDefinition)
+    if (definition.kind != "working group") {
+      activeFilters.push(filterDefinition)
+    }
     if (await definition.filter.isEnabled()) {
       toggleableFilters.push(filterDefinition)
     }


### PR DESCRIPTION
See https://github.com/graphql/graphql.github.io/pull/2288#issuecomment-3729788114

I'm currently unable to run the website locally because of:

```
$ pnpm dev

> @0.0.0 dev /Users/martinbonnin/git/graphql.github.io
> next

  ▲ Next.js 14.2.35
  - Local:        http://localhost:3000

 ✓ Starting...
 ⚠ Invalid next.config.js options detected:
 ⚠     Unrecognized key(s) in object: 'typedRoutes'
 ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config
   automatically enabled Fast Refresh for 2 custom loaders
 ✓ Ready in 1549ms
(node:27673) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
 ○ Compiling / ...
 ⨯ ./src/pages/index.mdx
TypeError: localStorage.getItem is not a function
 ⨯ ./src/pages/index.mdx
TypeError: localStorage.getItem is not a function
   automatically enabled Fast Refresh for 2 custom loaders
 ⨯ ./src/pages/index.mdx
TypeError: localStorage.getItem is not a function
 ⨯ Error: ENOENT: no such file or directory, open '/Users/martinbonnin/git/graphql.github.io/.next/fallback-build-manifest.json'
    at readFileSync (node:fs:435:20)
```

Not really sure what's going on, take this with a grain of salt.

Edit: Welp, that didn't seem to work in the preview either 😞 