### PR TITLE
Different links in community section of homepage

### DIFF
--- a/src/components/index-page/join-the-community.tsx
+++ b/src/components/index-page/join-the-community.tsx
@@ -17,14 +17,14 @@ export function JoinTheCommunity() {
         </div>
         <div className="flex flex-col *:flex-1">
           <Anchor
-            href="/community/tools-and-libraries"
+            href="https://discord.graphql.org/"
             className="flex items-center justify-between gap-4 whitespace-pre border-b border-pri-light px-6 py-8 hover:bg-white/10 lg:h-1/3 lg:px-8 lg:pr-12 xl:gap-6"
           >
             Discord
             <DiscordIcon className="size-8 fill-white" />
           </Anchor>
           <Anchor
-            href="/community/events"
+            href="/community/"
             className="flex items-center justify-between gap-4 whitespace-pre border-pri-light px-6 py-8 hover:bg-white/10 lg:h-1/3 lg:px-8 lg:pr-12 xl:gap-6"
           >
             Explore community resources


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

## Description

I noticed that the links in this pink community section at the bottom of the homepage didn't go to where they said: 

<img width="590" height="564" alt="Screenshot 2026-01-16 at 15 27 50" src="https://github.com/user-attachments/assets/607e9dcc-09f0-425d-a8fa-0792c9f12f66" />

Updated to a link to Discord, and a link to `/community/` which shows links to socials, youtube, discord, calendar etc. 
