### PR TITLE
Use the Button component in SME post

### DIFF
--- a/src/pages/blog/2026-01-16-seeking-graphql-subject-matter-experts/index.mdx
+++ b/src/pages/blog/2026-01-16-seeking-graphql-subject-matter-experts/index.mdx
@@ -25,15 +25,14 @@ If you fit one or more of these categories, apply today!
 * GraphQL security experts
 * Role not open to GraphQL TSC members - you will have a different role in program selection
 
+import { Button } from "@/app/conf/_design-system/button"
+
 <div className="mt-8 flex justify-center">
-  <a
+  <Button
     href="https://forms.gle/EfiTRcz5Y67bxBKm7"
-    target="_blank"
-    rel="noreferrer"
-    className="bg-primary/85 px-20 py-4 text-center text-3xl font-semibold transition-colors hover:bg-primary/100 md:px-28"
   >
     Apply Now
-  </a>
+  </Button>
 </div>
 
 ## Timeline
@@ -59,15 +58,12 @@ In parallel, the SMEs will be given a selection of the talk proposals based on t
 
 After these two rating methods, each talk will have two scores: a star rating from the TSC based on conference fit, and a rating from the SMEs reflecting subject content. The Program Committee will then start with the most highly rated talks and work to produce the schedule. Whilst the aim is to produce a schedule reflecting the TSC and SME ratings, the Program Committee will also act as a curator: making sure there is a good balance of talks from across different industries and affiliations, as well as looking at speaker diversity in terms of demographics and a balance between experienced and new speakers. 
 
-<div className="mt-8 flex justify-center">
-  <a
+<div className="my-8 flex justify-center">
+  <Button
     href="https://forms.gle/EfiTRcz5Y67bxBKm7"
-    target="_blank"
-    rel="noreferrer"
-    className="primary bg-primary/85 px-20 py-4 text-center text-3xl font-semibold transition-colors hover:bg-primary/100 md:px-28"
   >
     Apply to be an SME
-  </a>
+  </Button>
 </div>
 
 _Looking for the call for speakers? [Find it here on Sessionize.](https://sessionize.com/graphqlconf-2026/)_


### PR DESCRIPTION
## Description

Hey @jemgillam I noticed the contrast on the links in the SME posts in light mode is a bit low (i.e. below WCAG 1.4.3 Criterion).

<img width="316" height="243" alt="image" src="https://github.com/user-attachments/assets/f435eb23-a85f-4bf8-bf5c-ceb647b0aaa8" />

### Solution

I'd like to propose using the same button `Button` we use on the landing pages in the blogs, like this:

```tsx
import { Button } from "@/app/conf/_design-system/button";

<Button href="https://*" /> // renders HTMLAnchorElement with `target="_blank" rel="noreferrer"` 
```

