### PR TITLE
Remove "all rights reserved"

### DIFF
--- a/src/app/blog/rss.xml/route.ts
+++ b/src/app/blog/rss.xml/route.ts
@@ -53,7 +53,7 @@ export async function GET() {
     site_url: SITE_URL,
     // managingEditor: "info@graphql.org",
     // webMaster: "info@graphql.org",
-    copyright: `Copyright © ${new Date().getFullYear()} The GraphQL Foundation. All rights reserved.`,
+    copyright: `Copyright © ${new Date().getFullYear()} The GraphQL Foundation.`,
     language: "en-US",
     // Published date as last blog post date
     pubDate: blogs[0].frontMatter.date.toUTCString(),

--- a/src/app/conf/2025/components/footer/index.tsx
+++ b/src/app/conf/2025/components/footer/index.tsx
@@ -46,8 +46,7 @@ export function Footer({
       <div className="relative flex justify-between gap-10 p-4 text-sm max-lg:flex-col md:px-6 2xl:px-10">
         <div className="flex flex-col font-light max-md:gap-5">
           <p>
-            Copyright © {new Date().getFullYear()} The GraphQL Foundation. All
-            rights reserved.
+            Copyright © {new Date().getFullYear()} The GraphQL Foundation.
           </p>
           <p>
             For web site terms of use, trademark policy and general project

--- a/src/app/conf/2025/components/footer/index.tsx
+++ b/src/app/conf/2025/components/footer/index.tsx
@@ -45,9 +45,7 @@ export function Footer({
       </ul>
       <div className="relative flex justify-between gap-10 p-4 text-sm max-lg:flex-col md:px-6 2xl:px-10">
         <div className="flex flex-col font-light max-md:gap-5">
-          <p>
-            Copyright © {new Date().getFullYear()} The GraphQL Foundation.
-          </p>
+          <p>Copyright © {new Date().getFullYear()} The GraphQL Foundation.</p>
           <p>
             For web site terms of use, trademark policy and general project
             policies please see{" "}

--- a/src/app/conf/_components/footer.tsx
+++ b/src/app/conf/_components/footer.tsx
@@ -44,9 +44,7 @@ export function Footer({
       </div>
       <div className="container flex justify-between gap-10 text-sm max-lg:flex-col">
         <div className="flex flex-col font-light max-md:gap-5">
-          <p>
-            Copyright © {new Date().getFullYear()} The GraphQL Foundation.
-          </p>
+          <p>Copyright © {new Date().getFullYear()} The GraphQL Foundation.</p>
           <p>
             For web site terms of use, trademark policy and general project
             policies please see{" "}

--- a/src/app/conf/_components/footer.tsx
+++ b/src/app/conf/_components/footer.tsx
@@ -45,8 +45,7 @@ export function Footer({
       <div className="container flex justify-between gap-10 text-sm max-lg:flex-col">
         <div className="flex flex-col font-light max-md:gap-5">
           <p>
-            Copyright © {new Date().getFullYear()} The GraphQL Foundation. All
-            rights reserved.
+            Copyright © {new Date().getFullYear()} The GraphQL Foundation.
           </p>
           <p>
             For web site terms of use, trademark policy and general project

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -177,8 +177,7 @@ export function Footer() {
             <ThemeSwitch />
           </div>
           <p className="typography-body-xs flex flex-col text-pretty max-md:gap-5">
-            Copyright © {new Date().getFullYear()} The GraphQL Foundation. All
-            rights reserved.
+            Copyright © {new Date().getFullYear()} The GraphQL Foundation.
           </p>
         </div>
       </div>


### PR DESCRIPTION
The foundation holds the copyright and the CLA has a copyright grant clause so I think it's correct to have the foundation as a copyright owner (disclaimer: not a lawyer!).

But I don't think it's correct to say "all rights reserved". This repo is licensed under MIT and anyone has rights to use it/distribute it according to the terms of the license (again: not a lawyer!).

Also looks like this sentence is slowly becoming obsolete (see https://en.wikipedia.org/wiki/All_rights_reserved)
