### PR TITLE
GraphQLConf 2026 — Flex wrap and sentence case

### DIFF
--- a/src/app/conf/2026/components/register-today/index.tsx
+++ b/src/app/conf/2026/components/register-today/index.tsx
@@ -37,11 +37,9 @@ export function RegisterToday({ className }: RegisterTodayProps) {
           </p>
         </div>
         <div className="mt-10 flex gap-x-6 gap-y-4 max-sm:flex-col">
-          <Button className="opacity-55" href={GET_TICKETS_LINK}>
-            Register
-          </Button>
-          <Button className="opacity-55" variant="secondary" href="#sponsors">
-            Explore Sponsorship
+          <Button href={GET_TICKETS_LINK}>Register</Button>
+          <Button variant="secondary" href="#sponsors">
+            Explore sponsorship
           </Button>
         </div>
       </div>

--- a/src/app/conf/2026/page.tsx
+++ b/src/app/conf/2026/page.tsx
@@ -29,12 +29,12 @@ export default function Page() {
     <main className="gql-all-anchors-focusable">
       <Hero year="2026" bottom={<HeroImage />}>
         <HeroDateAndLocation />
-        <Button className="md:w-fit" href={BECOME_A_SPEAKER_LINK}>
-          Submit Your Talk
-        </Button>
-        <Button className="md:w-fit" href={GET_TICKETS_LINK}>
-          Get Your Ticket
-        </Button>
+        <div className="flex flex-wrap gap-x-4 gap-y-2 max-xs:*:w-full sm:gap-x-6">
+          <Button href={BECOME_A_SPEAKER_LINK}>Submit your talk</Button>
+          <Button variant="tertiary" href={GET_TICKETS_LINK}>
+            Get a ticket
+          </Button>
+        </div>
       </Hero>
       <div className="gql-container gql-conf-navbar-strip text-neu-900 before:bg-white/40 before:dark:bg-blk/30">
         <MarqueeRows
@@ -73,7 +73,7 @@ export default function Page() {
               variant="primary"
               href={GET_TICKETS_LINK}
             >
-              Register Now
+              Register now
             </Button>
           </CtaCardSection>
           <MarqueeRows


### PR DESCRIPTION
## Description

Howdy 👋  I'd like to propose some changes to make the 2026 page a bit more consistent with previous year's design and give the hero a tiny bit more polish.

### What's changed

- Used `variant=tertiary` for one of the buttons in 2026 hero section
- Changed the button text casing to sentence case (matches the previous conf page, graphql.org, and tldr one of the designers behind the website is ex-Apple, so we're matching Apple Developer Guidelines and their readability studies)

### Screenshots

| Before | After |
| --- | --- |
|  <img width="1480" height="516" alt="image" src="https://github.com/user-attachments/assets/a9bac84b-398d-4eb2-9e43-1bce1f5c3020" /> | <img width="1485" height="427" alt="image" src="https://github.com/user-attachments/assets/f1f91799-86eb-49f4-85e3-8b5b43ee827c" /> |

