### PR TITLE
Add page about WG Day, May 08 (following GraphQLConf 2026)

### DIFF
--- a/src/app/conf/2026/components/call-for-proposals.tsx
+++ b/src/app/conf/2026/components/call-for-proposals.tsx
@@ -28,6 +28,10 @@ function DatesTab() {
         term="Event Dates"
         definition="Wednesday, May 6 - Thursday, May 7"
       />
+      <DefinitionListItem
+        term="WG Day"
+        definition="Friday, May 8 (9:30 AM - 4:30 PM)"
+      />
     </DefinitionListBox>
   )
 }

--- a/src/app/conf/2026/components/footer/index.tsx
+++ b/src/app/conf/2026/components/footer/index.tsx
@@ -33,6 +33,12 @@ export function Footer({
               07<span className="max-sm:hidden">, 2026</span>
             </time>
           </p>
+          <p className="flex items-center whitespace-pre">
+            WG Day:
+            <span className="ml-1">
+              <time dateTime="2026-05-08">May 08</time>
+            </span>
+          </p>
           <address className="not-italic">Menlo Park, California</address>
         </div>
       </div>

--- a/src/app/conf/2026/components/navbar.tsx
+++ b/src/app/conf/2026/components/navbar.tsx
@@ -66,6 +66,9 @@ export function Navbar({ links, year }: NavbarProps): ReactElement {
               <span>-</span>
               <time dateTime="2026-05-07">07, 2026</time>
             </p>
+            <p className="text-sm text-neu-800 dark:text-neu-100">
+              WG Day: <time dateTime="2026-05-08">May 08</time>
+            </p>
             <address className="text-sm not-italic">
               Menlo Park, California
             </address>

--- a/src/app/conf/2026/components/register-today/index.tsx
+++ b/src/app/conf/2026/components/register-today/index.tsx
@@ -36,10 +36,25 @@ export function RegisterToday({ className }: RegisterTodayProps) {
             shape the next decade of APIs!
           </p>
         </div>
-        <div className="mt-10 flex gap-x-6 gap-y-4 max-sm:flex-col">
+        <div className="mt-4 flex gap-x-6 gap-y-4 max-sm:flex-col">
           <Button href={GET_TICKETS_LINK}>Register</Button>
           <Button variant="secondary" href="#sponsors">
             Explore sponsorship
+          </Button>
+        </div>
+        <div className="mt-10">
+          <p className="typography-h4 mt-4 text-neu-800">
+            Following the conference,{" "}
+            <a className="typography-link" href="/conf/2026/wg-day">
+              WG Day
+            </a>{" "}
+            brings working group members and maintainers together to continue
+            the momentum.
+          </p>
+        </div>
+        <div className="mt-2 flex gap-x-6 gap-y-4 max-sm:flex-col">
+          <Button variant="secondary" href="/conf/2026/wg-day/">
+            WG Day
           </Button>
         </div>
       </div>

--- a/src/app/conf/2026/faq.tsx
+++ b/src/app/conf/2026/faq.tsx
@@ -13,6 +13,19 @@ const FAQS = [
     ),
   },
   {
+    question: "Is anything happening on May 08 after the main conference?",
+    answer: (
+      <>
+        Working Group Day is on May 08, 2026. For attendance, schedule, and
+        day-of logistics, see{" "}
+        <a className="typography-link" href="/conf/2026/wg-day">
+          the WG Day page
+        </a>
+        .
+      </>
+    ),
+  },
+  {
     question: "Can I sponsor the event?",
     answer: (
       <>

--- a/src/app/conf/2026/layout.tsx
+++ b/src/app/conf/2026/layout.tsx
@@ -46,6 +46,7 @@ export default function Layout({
             href: "https://register.linuxfoundation.org/graphql-conf-2026",
           },
           { children: "Sponsors", href: "/conf/2026/#sponsors" },
+          { children: "WG Day", href: "/conf/2026/wg-day" },
           { children: "Resources", href: "/conf/2026/resources" },
           {
             children: "2025 Event Photos",

--- a/src/app/conf/2026/page.tsx
+++ b/src/app/conf/2026/page.tsx
@@ -21,7 +21,7 @@ import { HeroImage } from "./components/hero/hero-image"
 import { HERO_MARQUEE_ITEMS } from "./utils"
 
 export const metadata: Metadata = {
-  title: "GraphQLConf 2026 — May 06-07",
+  title: "GraphQLConf 2026 — May 06-07 + WG Day May 08",
 }
 
 export default function Page() {

--- a/src/app/conf/2026/page.tsx
+++ b/src/app/conf/2026/page.tsx
@@ -68,11 +68,7 @@ export default function Page() {
             title="Get your ticket"
             description="Join two transformative days of expert insights and innovation to shape the next decade of APIs!"
           >
-            <Button
-              className="opacity-55"
-              variant="primary"
-              href={GET_TICKETS_LINK}
-            >
+            <Button variant="primary" href={GET_TICKETS_LINK}>
               Register now
             </Button>
           </CtaCardSection>

--- a/src/app/conf/2026/wg-day/page.tsx
+++ b/src/app/conf/2026/wg-day/page.tsx
@@ -67,8 +67,8 @@ export default function WGDayPage() {
               group participants first. Additional attendees can join via a
               waitlist, with priority for maintainers of GraphQL-related open
               source software (clients, servers, libraries, frameworks, tooling,
-              and documentation), plus Foundation board members and GraphQL Ambassadors. Room
-              capacity is 48.
+              and documentation), plus Foundation board members and GraphQL
+              Ambassadors. Room capacity is 48.
             </p>
           </article>
 
@@ -78,13 +78,14 @@ export default function WGDayPage() {
               <li>
                 Location: Meta MPK 21 (adjacent to the main conference building)
               </li>
-              <li>Time: Drop-in between 9:30 AM-4:30 PM PT (last entry 2:00 PM</li>
+              <li>
+                Time: Drop-in between 9:30 AM-4:30 PM PT (last entry 2:00 PM
+              </li>
               <li>
                 Informal format: drop in and out as needed; early departures for
                 travel are absolutely fine
               </li>
-              <li>
-              </li>
+              <li></li>
               <li>
                 Lunch plan: we expect to head to the cafeteria; if you arrive
                 around midday, you may need to meet the group there

--- a/src/app/conf/2026/wg-day/page.tsx
+++ b/src/app/conf/2026/wg-day/page.tsx
@@ -78,7 +78,6 @@ export default function WGDayPage() {
               <li>
                 Location: Meta MPK 21 (adjacent to the main conference building)
               </li>
-              <li>Setup: Classroom-style seating for note-taking</li>
               <li>Time: Drop-in between 9:30 AM-4:30 PM PT (last entry 2:00 PM</li>
               <li>
                 Informal format: drop in and out as needed; early departures for

--- a/src/app/conf/2026/wg-day/page.tsx
+++ b/src/app/conf/2026/wg-day/page.tsx
@@ -1,0 +1,115 @@
+import { Metadata } from "next"
+
+import { Button } from "@/app/conf/_design-system/button"
+
+import { Hero, HeroStripes } from "../components/hero"
+import { NavbarPlaceholder } from "../components/navbar"
+
+export const metadata: Metadata = {
+  title: "WG Day | GraphQLConf 2026",
+  description:
+    "Working Group Day at GraphQLConf 2026 on May 08 in Menlo Park for GraphQL working group members and maintainers of key GraphQL OSS, with intentionally unstructured time for technical discussion and social connection.",
+}
+
+export default function WGDayPage() {
+  return (
+    <>
+      <NavbarPlaceholder className="top-0 bg-neu-100 before:bg-white/30 dark:bg-[#181A12] dark:before:bg-blk/40" />
+      <Hero
+        pageName="WG Day"
+        year="2026"
+        colorScheme="neutral"
+        stripes={
+          <HeroStripes
+            className="-scale-x-100 dark:data-[loaded=true]:opacity-80"
+            evenClassName="bg-[linear-gradient(180deg,hsl(var(--color-sec-light))_0%,hsl(319deg_100%_90%_/_0.2)_100%)] dark:bg-[linear-gradient(180deg,hsl(var(--color-sec-dark))_0%,hsl(var(--color-neu-100))_100%)]"
+            oddClassName="bg-[linear-gradient(180deg,hsl(319deg_100%_90%_/_0.2)_0%,hsl(var(--color-sec-base))_100%)] dark:bg-[linear-gradient(180deg,hsl(var(--color-sec-dark))_0%,hsl(var(--color-neu-0))_100%)]"
+          />
+        }
+      >
+        <p className="typography-body-lg max-w-3xl">
+          A day for GraphQL working group members and maintainers of key GraphQL
+          open source software to socialize, strategize, and build on the
+          momentum of the main conference.
+        </p>
+        <div className="flex flex-wrap gap-x-6 gap-y-2">
+          <p className="typography-body-md">
+            <strong>Date:</strong>{" "}
+            <time dateTime="2026-05-08">May 08, 2026</time>
+          </p>
+          <p className="typography-body-md">
+            <strong>Time:</strong> 9:30 AM-4:30 PM PT
+          </p>
+          <p className="typography-body-md">
+            <strong>Location:</strong> Meta MPK 21, Menlo Park
+          </p>
+        </div>
+      </Hero>
+
+      <main className="gql-all-anchors-focusable gql-conf-navbar-strip text-neu-900 before:bg-white/40 before:dark:bg-blk/30">
+        <section className="gql-container gql-section space-y-10 xl:mb-16 xl:mt-8">
+          <article className="space-y-4">
+            <h2 className="typography-h2">What it is</h2>
+            <p className="typography-body-lg max-w-4xl">
+              WG Day is a low-overhead in-person collaboration day right after
+              GraphQLConf. There is no fixed schedule, no recording, and no
+              formal programming. This unstructured format is deliberate: it is
+              equally valid to spend the day diving deep on proposals, planning
+              across groups, or simply socializing and getting to know each
+              other.
+            </p>
+          </article>
+
+          <article className="space-y-4">
+            <h2 className="typography-h2">Attendance</h2>
+            <p className="typography-body-lg max-w-4xl">
+              Capacity is limited, so invitations will go to regular working
+              group participants first. Additional attendees can join via a
+              waitlist, with priority for maintainers of GraphQL-related open
+              source software (clients, servers, libraries, frameworks, tooling,
+              and documentation), plus board members and ambassadors. Room
+              capacity is 48.
+            </p>
+          </article>
+
+          <article className="space-y-4">
+            <h2 className="typography-h2">Logistics</h2>
+            <ul className="typography-body-lg list-disc space-y-2 pl-5">
+              <li>
+                Location: Meta MPK 21 (adjacent to the main conference building)
+              </li>
+              <li>Setup: Classroom-style seating for note-taking</li>
+              <li>Booked hours: 9:00 AM-5:00 PM PT</li>
+              <li>Suggested discussion window: 9:30 AM-4:30 PM PT</li>
+              <li>
+                Informal format: drop in and out as needed; early departures for
+                travel are absolutely fine
+              </li>
+              <li>
+                Arrival guidance: please arrive by 2:00 PM when possible
+                (attendance may wind down earlier and hosts may close early)
+              </li>
+              <li>
+                Lunch plan: we expect to head to the cafeteria; if you arrive
+                around midday, you may need to meet the group there
+              </li>
+            </ul>
+          </article>
+
+          <article className="space-y-4">
+            <h2 className="typography-h2">Contact</h2>
+            <p className="typography-body-lg max-w-4xl">
+              Questions about attendance, waitlist priority, or logistics:
+            </p>
+            <Button
+              href="mailto:graphql_events@linuxfoundation.org?subject=GraphQLConf%202026%20WG%20Day"
+              className="w-fit"
+            >
+              Email the event team
+            </Button>
+          </article>
+        </section>
+      </main>
+    </>
+  )
+}

--- a/src/app/conf/2026/wg-day/page.tsx
+++ b/src/app/conf/2026/wg-day/page.tsx
@@ -99,7 +99,7 @@ export default function WGDayPage() {
               Questions about attendance, waitlist priority, or logistics:
             </p>
             <Button
-              href="mailto:graphql_events@linuxfoundation.org?subject=GraphQLConf%202026%20WG%20Day"
+              href="mailto:operations@graphql.org?subject=GraphQLConf%202026%20WG%20Day"
               className="w-fit"
             >
               Email the event team

--- a/src/app/conf/2026/wg-day/page.tsx
+++ b/src/app/conf/2026/wg-day/page.tsx
@@ -84,8 +84,6 @@ export default function WGDayPage() {
                 travel are absolutely fine
               </li>
               <li>
-                Arrival guidance: please arrive by 2:00 PM when possible
-                (attendance may wind down earlier and hosts may close early)
               </li>
               <li>
                 Lunch plan: we expect to head to the cafeteria; if you arrive

--- a/src/app/conf/2026/wg-day/page.tsx
+++ b/src/app/conf/2026/wg-day/page.tsx
@@ -49,7 +49,7 @@ export default function WGDayPage() {
       <main className="gql-all-anchors-focusable gql-conf-navbar-strip text-neu-900 before:bg-white/40 before:dark:bg-blk/30">
         <section className="gql-container gql-section space-y-10 xl:mb-16 xl:mt-8">
           <article className="space-y-4">
-            <h2 className="typography-h2">What it is</h2>
+            <h2 className="typography-h2">What is it?</h2>
             <p className="typography-body-lg max-w-4xl">
               WG Day is a low-overhead in-person collaboration day right after
               GraphQLConf. There is no fixed schedule, no recording, and no
@@ -67,7 +67,7 @@ export default function WGDayPage() {
               group participants first. Additional attendees can join via a
               waitlist, with priority for maintainers of GraphQL-related open
               source software (clients, servers, libraries, frameworks, tooling,
-              and documentation), plus board members and ambassadors. Room
+              and documentation), plus Foundation board members and GraphQL Ambassadors. Room
               capacity is 48.
             </p>
           </article>
@@ -79,8 +79,7 @@ export default function WGDayPage() {
                 Location: Meta MPK 21 (adjacent to the main conference building)
               </li>
               <li>Setup: Classroom-style seating for note-taking</li>
-              <li>Booked hours: 9:00 AM-5:00 PM PT</li>
-              <li>Suggested discussion window: 9:30 AM-4:30 PM PT</li>
+              <li>Time: Drop-in between 9:30 AM-4:30 PM PT (last entry 2:00 PM</li>
               <li>
                 Informal format: drop in and out as needed; early departures for
                 travel are absolutely fine


### PR DESCRIPTION
@Keweiqu has managed to arrange us a room on May 8th for WG members and related parties to socialize and collaborate. It'll be a very unstructured day enabling lots of random conversations which will hopefully help us capture some of the momentum and energy from the conference and channel it into making progress; or just strengthening our bonds as a community. The room has a capacity of 48 people, so we'll be prioritising WG members first (i.e. GraphQL stars) but we hope to also see OSS maintainers, board members and ambassadors in the room!