### PR TITLE
Force blog timestamps to be in UTC

### DIFF
--- a/src/app/(main)/resources/blog-post-list-item.tsx
+++ b/src/app/(main)/resources/blog-post-list-item.tsx
@@ -23,6 +23,7 @@ export function BlogPostListItem({
       day: "2-digit",
       month: "2-digit",
       year: "numeric",
+      timeZone: "UTC",
     })
     .replaceAll("/", "-")
 

--- a/src/components/blog-page/blog-card.tsx
+++ b/src/components/blog-page/blog-card.tsx
@@ -95,6 +95,7 @@ export function BlogCardFooterContent({
           month: "long",
           day: "numeric",
           year: "numeric",
+          timeZone: "UTC",
         })}
       </time>
     </span>

--- a/src/pages/blog/_meta.tsx
+++ b/src/pages/blog/_meta.tsx
@@ -44,6 +44,7 @@ export default {
                   month: "long",
                   day: "numeric",
                   year: "numeric",
+                  timeZone: "UTC",
                 })}
               </time>
             </div>


### PR DESCRIPTION
Fixes an issue where timestamps rendered different dates depending on the user's location:

<img width="695" height="359" alt="Screenshot 2026-04-01 at 12 49 32 PM" src="https://github.com/user-attachments/assets/1b029ffa-a452-4bf8-ac84-d95f15e7b02c" />
<img width="695" height="2400" alt="image" src="https://github.com/user-attachments/assets/e3882000-b075-49da-8e02-6ae976590d15" />

