### PR TITLE
Remove caniuse.graphql.org proposal from project list

### DIFF
--- a/src/pages/blog/2026-04-13-call-for-projects.mdx
+++ b/src/pages/blog/2026-04-13-call-for-projects.mdx
@@ -34,7 +34,6 @@ For example, these topics have been discussed recently in the community and woul
 * Implement [semantic introspection](https://github.com/graphql/ai-wg/blob/main/rfcs/semantic-introspection.md) in graphql-js to make it easier for agents to discover GraphQL schemas and types.
 * Implement new experimental GraphQL features such as [`onError` or service capabilities](https://github.com/graphql/graphql-spec/pull/1163) in graphql-js.
 * Implement a type-safe query builder library using TypeScript.
-* Design and implement a "[caniuse.graphql.org](https://github.com/graphql/community-wg/issues/165)" website to make it easy to see at a glance what experimental features are supported in different frameworks.
 * Propose and implement an alternative way to thread in inputs to @skip/@include (highlighted as a problem [here](https://www.youtube.com/watch?t=498&v=Orgyp3xOqwY&feature=youtu.be)).
 * Design and implement a [content hub](https://github.com/graphql/community-wg/issues/158) for easily spreading the word about GraphQL.
 * Run a [GraphQL survey](https://github.com/graphql/community-wg/issues/55).


### PR DESCRIPTION
No need for a grant there, I've made it available there: https://caniuse.graphql.now/