### PR TITLE
Add PSGraphQL to language support

### DIFF
--- a/src/code/language-support/powershell/client/psgraphql.md
+++ b/src/code/language-support/powershell/client/psgraphql.md
@@ -1,0 +1,38 @@
+---
+
+name: PSGraphQL
+description: A PowerShell module for querying and mutating GraphQL endpoints.
+github: anthonyg-1/PSGraphQL
+tags:
+
+* tools-and-libraries
+* frontend
+
+---
+
+PSGraphQL is a PowerShell module for working with GraphQL endpoints from scripts, shells, and automation workflows. It provides commands for sending GraphQL queries and mutations, passing variables, setting headers, and returning either PowerShell objects or raw JSON.
+
+Install it from the PowerShell Gallery:
+
+```powershell
+Install-Module -Name PSGraphQL -Scope CurrentUser
+```
+
+Run a simple GraphQL query:
+
+```powershell
+$uri = "https://mytargetserver/v1/graphql"
+
+$query = @'
+query {
+  users {
+    id
+    name
+  }
+}
+'@
+
+Invoke-GraphQLQuery -Uri $uri -Query $query
+```
+
+PSGraphQL can also send mutations, include operation names and variables, use custom headers for authentication, and read GraphQL queries from files.

--- a/src/code/language-support/powershell/client/psgraphql.md
+++ b/src/code/language-support/powershell/client/psgraphql.md
@@ -1,13 +1,10 @@
 ---
-
 name: PSGraphQL
 description: A PowerShell module for querying and mutating GraphQL endpoints.
 github: anthonyg-1/PSGraphQL
 tags:
-
-* tools-and-libraries
-* frontend
-
+  - tools-and-libraries
+  - frontend
 ---
 
 PSGraphQL is a PowerShell module for working with GraphQL endpoints from scripts, shells, and automation workflows. It provides commands for sending GraphQL queries and mutations, passing variables, setting headers, and returning either PowerShell objects or raw JSON.

--- a/src/code/slug-map.json
+++ b/src/code/slug-map.json
@@ -16,6 +16,7 @@
   "julia": "Julia",
   "perl": "Perl",
   "php": "PHP",
+  "powershell": "PowerShell",
   "python": "Python",
   "r": "R",
   "ruby": "Ruby",


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

## Description

Adds PSGraphQL as a PowerShell GraphQL client library under Language Support.

PSGraphQL is a PowerShell module for querying and mutating GraphQL endpoints from scripts, shells, and automation workflows. It is published on the PowerShell Gallery and supports Windows, Linux, and macOS.

Changes:
- Adds `PowerShell` to the Code page slug map
- Adds `PSGraphQL` under `language-support/powershell/client`
