### PR TITLE
conf 2026: post-conference update

### DIFF
--- a/src/app/conf/2026/components/become-a-sponsor/index.tsx
+++ b/src/app/conf/2026/components/become-a-sponsor/index.tsx
@@ -23,7 +23,8 @@ export function BecomeASponsor() {
             href="https://events.linuxfoundation.org/sponsor-graphqlconf26"
             target="_blank"
             rel="noreferrer"
-            className="md:w-fit"
+            className="opacity-55 md:w-fit"
+            disabled
           >
             Sponsor
           </Button>

--- a/src/app/conf/2026/components/register-today/index.tsx
+++ b/src/app/conf/2026/components/register-today/index.tsx
@@ -37,7 +37,9 @@ export function RegisterToday({ className }: RegisterTodayProps) {
           </p>
         </div>
         <div className="mt-4 flex gap-x-6 gap-y-4 max-sm:flex-col">
-          <Button href={GET_TICKETS_LINK}>Register</Button>
+          <Button href={GET_TICKETS_LINK} className="opacity-55" disabled>
+            Sold out
+          </Button>
           <Button variant="secondary" href="#sponsors">
             Explore sponsorship
           </Button>

--- a/src/app/conf/2026/layout.tsx
+++ b/src/app/conf/2026/layout.tsx
@@ -41,17 +41,13 @@ export default function Layout({
         year={2026}
         links={[
           // { children: "CFP", href: "https://sessionize.com/graphqlconf-2026/" },
-          {
-            children: "Register",
-            href: "https://register.linuxfoundation.org/graphql-conf-2026",
-          },
           { children: "Schedule", href: "/conf/2026/schedule" },
           { children: "Speakers", href: "/conf/2026/speakers" },
           { children: "Sponsors", href: "/conf/2026/#sponsors" },
           { children: "WG Day", href: "/conf/2026/wg-day" },
           { children: "Resources", href: "/conf/2026/resources" },
           {
-            children: "2025 Event Photos",
+            children: "2026 Event Photos",
             href: GALLERY_LINK,
           },
         ]}

--- a/src/app/conf/2026/links.ts
+++ b/src/app/conf/2026/links.ts
@@ -4,5 +4,4 @@ export const GET_TICKETS_LINK =
 export const BECOME_A_SPEAKER_LINK =
   "https://sessionize.com/graphqlconf-2026/?utm_source=graphql_conf_2026&utm_medium=website&utm_campaign=register_section"
 
-export const GALLERY_LINK =
-  "https://www.flickr.com/photos/linuxfoundation/sets/72177720328905487/"
+export const GALLERY_LINK = "https://photos.app.goo.gl/tCtSh85hmfh4AwgPA"

--- a/src/app/conf/2026/page.tsx
+++ b/src/app/conf/2026/page.tsx
@@ -34,8 +34,8 @@ export default function Page() {
       <Hero year="2026" bottom={<HeroImage />}>
         <HeroDateAndLocation />
         <div className="flex flex-wrap gap-x-4 gap-y-2 max-xs:*:w-full sm:gap-x-6">
-          <Button variant="tertiary" href={GET_TICKETS_LINK}>
-            Register
+          <Button variant="tertiary" href={GALLERY_LINK}>
+            Community-sourced Event Photos
           </Button>
         </div>
       </Hero>
@@ -71,8 +71,13 @@ export default function Page() {
             title="Get your ticket"
             description="Join two transformative days of expert insights and innovation to shape the next decade of APIs!"
           >
-            <Button variant="primary" href={GET_TICKETS_LINK}>
-              Register
+            <Button
+              variant="primary"
+              href={GET_TICKETS_LINK}
+              disabled
+              className="opacity-55"
+            >
+              Sold Out
             </Button>
           </CtaCardSection>
           <MarqueeRows

--- a/src/app/conf/2026/schedule/page.tsx
+++ b/src/app/conf/2026/schedule/page.tsx
@@ -27,7 +27,7 @@ export default function SchedulePage() {
     <main className="gql-all-anchors-focusable bg-neu-50 dark:bg-neu-0">
       <Hero pageName="Schedule" year={year}>
         <div className="mt-[18px] flex gap-4">
-          <Button className="" href={GET_TICKETS_LINK}>
+          <Button className="opacity-55" href={GET_TICKETS_LINK} disabled>
             Get Tickets
           </Button>
           <Button variant="tertiary" href={`/conf/${year}/speakers`}>

--- a/src/app/conf/2026/speakers/page.tsx
+++ b/src/app/conf/2026/speakers/page.tsx
@@ -20,7 +20,7 @@ export default function Page() {
     <main className="gql-all-anchors-focusable bg-neu-50 dark:bg-neu-0">
       <Hero pageName="Speakers" year={year}>
         <div className="mt-[18px] flex gap-4">
-          <Button className="" href={GET_TICKETS_LINK}>
+          <Button className="opacity-55" href={GET_TICKETS_LINK} disabled>
             Get tickets
           </Button>
           <Button variant="tertiary" href={`/conf/${year}/schedule`}>

--- a/src/app/conf/2026/wg-day/page.tsx
+++ b/src/app/conf/2026/wg-day/page.tsx
@@ -116,16 +116,10 @@ export default function WGDayPage() {
             <div className="mt-4 flex gap-x-6 gap-y-4 max-sm:flex-col">
               <Button
                 href="https://forms.gle/jV5seEm8VHhsNLUs6"
-                className="w-fit"
+                className="w-fit opacity-55"
+                disabled
               >
-                Attend
-              </Button>
-              <Button
-                href="mailto:operations@graphql.org?subject=GraphQLConf%202026%20WG%20Day"
-                className="w-fit"
-                variant="secondary"
-              >
-                Email the event team
+                Event has passed
               </Button>
             </div>
           </article>


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

**Conf 2026 website** 

Disables buttons for getting a ticket, adds button for viewing the community sourced photo gallery to the hero of the website. Essentially, I have copied what the 2025 website did post event. 