### PR TITLE
Ambassador pages overhaul

### DIFF
--- a/src/pages/community/ambassadors/_meta.tsx
+++ b/src/pages/community/ambassadors/_meta.tsx
@@ -1,5 +1,6 @@
 export default {
   index: "Ambassadors",
   apply: "How to Apply",
+  requirements: "Ambassador Requirements",
   standards: "Standards of Excellence",
 }

--- a/src/pages/community/ambassadors/apply.mdx
+++ b/src/pages/community/ambassadors/apply.mdx
@@ -24,69 +24,28 @@ As an Ambassador, you also gain the following:
   speaking and creating content
 - Exclusive benefits and swag
 
+## Before You Apply
+
+The GraphQL Ambassador Program is a **recognition and support program, not a training program**.
+
+Applicants are expected to already be actively educating, supporting, or growing the GraphQL community before they apply.
+
+Successful applicants typically have an established track record of activities such as:
+
+- Giving GraphQL talks at meetups or conferences
+- Organising GraphQL-focused events
+- Creating GraphQL articles, videos, podcasts, or educational materials
+- Contributing to GraphQL Foundation projects or specifications
+- Maintaining a significant GraphQL open source project
+
+**Applications should include links demonstrating these activities**. If you are passionate about GraphQL but have not yet begun these activities, we encourage you to start contributing to the community and apply in a future cohort. See the [full list of Ambassador requirements on the Ambassador Requirements page](./requirements).
+
 <Button
   href="https://forms.gle/qXYEoG7iUatAb5bh6"
   className="mx-auto my-6 !block"
 >
   Application Form
 </Button>
-
-## Ambassador Requirements
-
-- Knowledgeable about GraphQL and readily able to articulate those ideas
-- A model community member: adhering to the Standards of Excellence especially
-  when critical of GraphQL or defending it against others' criticism; remaining
-  respectful, constructive and fair
-- Do not come across to other community members as selling another product,
-  service or agenda when acting as an Ambassador
-- Agree to have your face, name, chosen socials and other relevant information
-  displayed on the [Ambassadors](./) webpage
-- Already participate in one or more of the Ambassador tasks outlined below
-
-## Ambassador Tasks
-
-GraphQL Ambassadors are an important touchstone for people interested in GraphQL
-to learn more about it in a friendly and constructive way.
-
-As an Ambassador, you will do four or more Ambassador tasks throughout your one
-year term. Your can do the same task four times, or a mixture of tasks.
-
-Ambassador tasks include:
-
-<Steps>
-
-### Community Leadership
-  - Local Gathering organizer
-  - Organizer/program planner for a GraphQL focused event, conference track, or similar
-  - Mentorship hours
-  - GraphQL Foundation community Discord moderation
-
-### Public Speaking
-  - Speaking at industry, community or GraphQL Foundation events about GraphQL or GraphQL
-    projects
-
-### GraphQL Focused Content Creation
-  - Producing written content, both on GraphQL Foundation platforms and elsewhere
-  - Have written a GraphQL focused book
-  - Producing video and/or audio content, either on GraphQL Foundation platforms or elsewhere
-  - Building demo apps
-
-### Active Contribution to a GraphQL Foundation Project or Specification
-  - Have held a formal role in a GraphQL Foundation project
-  - Shared valuable insights or feedback at the GraphQL working group or sub-working groups
-
-### Maintainer or A Main Contributor of a Key Open-Source GraphQL Related Project
-  - For example, GraphQL clients, servers, tooling or implementations
-
-### Outreach for GraphQL Foundation initiatives
-  - Discussion and guidance helping a non-Foundation project to adopt, test and provide feedback on a GraphQL Specification proposal
-  - Organizing a venue for a GraphQL Local
-  - Media outreach with a measurable impact e.g. publication in a major tech outlet or mainstream media
-
-</Steps>
-
-_Note: content should align with open-source principles and not be behind
-paywalls_
 
 ## What the Foundation offers
 
@@ -100,7 +59,6 @@ paywalls_
 - Promotion of the Ambassador as a go-to GraphQL community leader:
   - Website profile
   - Biographies / interviews with each Ambassador
-  - Credly badge for social media profiles
 - An Ambassador role on the community Discord and an associated private channel
   for networking and discussions with Foundation / TSC / community reps
 - Promotion of Ambassador material - conference talk videos and created content
@@ -108,18 +66,6 @@ paywalls_
 - Travel funding to approved conference & meetup
   talks, applications to be evaluated on a case-by-case basis
 - An honorarium available for content creation on a case-by-case basis
-
-## Ambassador Code of Conduct
-
-While the wider GraphQL community abides by the
-[contributor covenant code of conduct](https://graphql.org/codeofconduct/), a
-stronger set of standards is used for the Ambassador Program. This is because
-the Foundation endorses Ambassadors as representatives and leaders; the
-Standards of Excellence are designed to provide a set of guidelines and best
-practices for engaging with the GraphQL Foundation and broader community. This
-makes it easier for Ambassadors to contribute to a positive culture by providing
-clarity around what and how we create a safe and collaborative environment. See
-[Standards of Excellence](./standards-of-excellence.md).
 
 ## Application Process
 
@@ -141,6 +87,16 @@ community member.
 | Year round        | November 2025 | December 2025 | November 2026 |
 | Year round        | February 2026 | March 2026 | February 2027 |
 | Year round        | May 2026 | June 2026 | April 2027 |
+| Year round        | August 2026 | September 2026 | August 2027 | 
+
+## Is this a Student Ambassador Program?
+
+No. The GraphQL Ambassador Program differs from many student ambassador programs. Student ambassador programs often recruit people first and then provide training and opportunities.
+
+The GraphQL Ambassador Program recognises and supports people who are **already making significant contributions to the GraphQL community**.
+
+Students are welcome to apply, but they are evaluated using the same criteria as all other applicants and must demonstrate an existing track record of GraphQL community engagement.
+
 
 ## Apply
 
@@ -154,4 +110,4 @@ Are you interested in becoming an official GraphQL Ambassador?
 </Button>
 
 Want to nominate someone else? [Fill in the nomination form instead](https://forms.gle/JcZ5XgUuRBsAF6T19). <br />
-Have a question? Please ask [ambassadors@graphql.org](mailto:ambassadors@graphql.org)
+Have a question? Send your questions to [ambassadors@graphql.org](mailto:ambassadors@graphql.org)

--- a/src/pages/community/ambassadors/requirements.mdx
+++ b/src/pages/community/ambassadors/requirements.mdx
@@ -1,0 +1,102 @@
+---
+description: Ambassador Requirements
+---
+
+import { Button } from "../../../app/conf/_components/button"
+import { Steps } from 'nextra/components'
+
+# What is a GraphQL Ambassador?
+
+GraphQL Ambassadors are trusted go-to community leaders driven by a passion for
+GraphQL projects and strive to nurture the growing GraphQL community through
+collaboration, education and outreach.
+
+## Ambassador Requirements
+
+- Knowledgeable about GraphQL and readily able to articulate those ideas
+- A model community member: adhering to the Standards of Excellence especially
+  when critical of GraphQL or defending it against others' criticism; remaining
+  respectful, constructive and fair
+- Do not come across to other community members as selling another product,
+  service or agenda when acting as an Ambassador
+- Agree to have your face, name, chosen socials and other relevant information
+  displayed on the [Ambassadors](./) webpage
+- **Already participate in one or more of the Ambassador tasks outlined below**
+
+<Button
+  href="https://forms.gle/qXYEoG7iUatAb5bh6"
+  className="mx-auto my-6 !block"
+>
+  Application Form
+</Button>
+
+## Ambassador Tasks
+
+GraphQL Ambassadors are an important touchstone for people interested in GraphQL
+to learn more about it in a friendly and constructive way.
+
+As an Ambassador, you will do four or more Ambassador tasks throughout your one
+year term. Your can do the same task four times, or a mixture of tasks.
+
+Ambassador tasks include:
+
+<Steps>
+
+### Community Leadership
+  - Local Gathering organizer
+  - Organizer/program planner for a GraphQL focused event, conference track, or similar
+  - Mentorship hours
+  - GraphQL Foundation community Discord moderation
+
+### Public Speaking
+  - Speaking at industry, community or GraphQL Foundation events about GraphQL or GraphQL
+    projects
+
+### GraphQL Focused Content Creation
+  - Producing written content, both on GraphQL Foundation platforms and elsewhere
+  - Have written a GraphQL focused book
+  - Producing video and/or audio content, either on GraphQL Foundation platforms or elsewhere
+  - Building demo apps
+
+### Active Contribution to a GraphQL Foundation Project or Specification
+  - Have held a formal role in a GraphQL Foundation project
+  - Shared valuable insights or feedback at the GraphQL working group or sub-working groups
+
+### Maintainer or A Main Contributor of a Key Open-Source GraphQL Related Project
+  - For example, GraphQL clients, servers, tooling or implementations
+
+### Outreach for GraphQL Foundation initiatives
+  - Discussion and guidance helping a non-Foundation project to adopt, test and provide feedback on a GraphQL Specification proposal
+  - Organizing a venue for a GraphQL Local
+  - Media outreach with a measurable impact e.g. publication in a major tech outlet or mainstream media
+
+</Steps>
+
+_Note: content should align with open-source principles and not be behind
+paywalls_
+
+## Ambassador Code of Conduct
+
+While the wider GraphQL community abides by the
+[contributor covenant code of conduct](https://graphql.org/codeofconduct/), a
+stronger set of standards is used for the Ambassador Program. This is because
+the Foundation endorses Ambassadors as representatives and leaders; the
+Standards of Excellence are designed to provide a set of guidelines and best
+practices for engaging with the GraphQL Foundation and broader community. This
+makes it easier for Ambassadors to contribute to a positive culture by providing
+clarity around what and how we create a safe and collaborative environment. See
+[Standards of Excellence](./standards-of-excellence.md).
+
+## Apply
+
+Are you interested in becoming an official GraphQL Ambassador?
+
+<Button
+  href="https://forms.gle/6HbGVrWc7no5zmEq7"
+  className="mx-auto my-6 !block"
+>
+  Application Form
+</Button>
+
+Want to nominate someone else? [Fill in the nomination form instead](https://forms.gle/JcZ5XgUuRBsAF6T19). <br />
+Have a question? Please ask [ambassadors@graphql.org](mailto:ambassadors@graphql.org)


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

I have split the Ambassador application page into two, hopefully this makes it much clearer that the program is intended as a recognition and support program, not a training program. 