### PR TITLE
Prevent page shift when navbar dropdown opens

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -368,6 +368,13 @@ footer {
   background-repeat: no-repeat;
 }
 
+/* Reserve the scrollbar gutter so opening a navbar dropdown (which locks
+   body scroll via `overflow: hidden`) doesn't remove the scrollbar and shift
+   the whole page sideways by the scrollbar width. */
+html {
+  scrollbar-gutter: stable;
+}
+
 /* without this Headless UI breaks sticky navbar */
 html:has([role="listbox"][data-open]),
 html:has([role="menu"][data-open]) {


### PR DESCRIPTION
## Problem

Opening a navbar dropdown (e.g. **Community**) locks page scroll by setting `body { overflow: hidden }` (`src/components/navbar/navbar.tsx`). On pages tall enough to show a scrollbar, this removes the ~15px viewport scrollbar. Because no space was reserved for it, the whole page — including the full-width navbar — shifts sideways by the scrollbar width as the menu opens and back when it closes.

## Fix

Reserve the scrollbar gutter on `html` so the layout width stays constant whether or not the scrollbar is present:

```css
html {
  scrollbar-gutter: stable;
}
```

This is consistent with the `scrollbar-gutter: stable` already used on `.nextra-scrollbar`, and also covers the mobile menu and any other scroll-lock.

> Note: `padding-right` compensation (the usual scroll-lock trick) does **not** work here, because the navbar is full-viewport-width and isn't constrained by the body content box.

## Verification

Measured the navbar's right edge while clicking the Community trigger:

| | scrollbar-gutter | nav right edge (closed → open) | shift |
|---|---|---|---|
| Before | `auto` | 1490 → 1505 | **15px** |
| After | `stable` | 1490 → 1490 | **0px** |

The scroll-lock still works as before; it just no longer shifts the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
