### PR TITLE
Add Airbnb Viaduct to tools-and-libraries

### DIFF
--- a/src/code/language-support/java-kotlin-android/server/viaduct.md
+++ b/src/code/language-support/java-kotlin-android/server/viaduct.md
@@ -1,0 +1,15 @@
+---
+name: Viaduct
+description: Viaduct is a GraphQL-based system that provides a unified interface for accessing and interacting with any data source.
+url: https://viaduct.dev
+github: airbnb/viaduct
+tags:
+  - tools-and-libraries
+  - backend
+---
+
+Viaduct is Airbnb's open-source, data-oriented service mesh built around a single, highly connected central GraphQL schema. It provides a unified interface for accessing and interacting with any data source, and its engine runs in production at scale at Airbnb.
+
+At the heart of Viaduct's developer experience is re-entrancy: logic hosted on Viaduct composes with other logic hosted on Viaduct by issuing GraphQL fragments and queries. Re-entrancy is crucial for maintaining modularity in a large codebase and avoiding classic monolith hazards.
+
+See the [Viaduct documentation](https://viaduct.dev) to get started.


### PR DESCRIPTION
## What

Adds [Viaduct](https://viaduct.dev) — Airbnb's open-source GraphQL framework — to the [`/community/tools-and-libraries`](https://graphql.org/community/tools-and-libraries) listing. It was missing (previously only mentioned in the GraphQLConf 2025 recap blog post).

## Details

- **Repo:** `airbnb/viaduct` · **Homepage:** https://viaduct.dev · **Language:** Kotlin (JVM)
- New entry: `src/code/language-support/java-kotlin-android/server/viaduct.md`, placed under **Java / Kotlin → Server** to match its primary language.
- The listing auto-generates from `src/code/**/*.md` and pulls star counts from the `github` field, so no other changes are needed.

Closes #2454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
