### PR TITLE
Rename Banana Cake Pop to Nitro in tools-and-libraries

### DIFF
--- a/src/code/services/bananacakepop.md
+++ b/src/code/services/bananacakepop.md
@@ -1,9 +1,0 @@
----
-name: Banana Cake Pop
-description: A feature-rich GraphQL IDE by [ChilliCream](https://chillicream.com) that let's you explore, manage, and test your GraphQL APIs. Check it out [here](https://bananacakepop.com).
-url: https://bananacakepop.com
-github: ChilliCream/hotchocolate
-tags:
-  - tools-and-libraries
-  - tools
----

--- a/src/code/services/nitro.md
+++ b/src/code/services/nitro.md
@@ -1,0 +1,12 @@
+---
+name: Nitro
+description: A GraphQL API management platform by [ChilliCream](https://chillicream.com/?utm_source=graphql_org&utm_medium=referral) that lets you explore, test, and monitor your APIs. It includes schema and client registries, telemetry, federation support, and a full-featured GraphQL IDE.
+url: https://get-nitro.chillicream.com/?utm_source=graphql_org&utm_medium=referral
+github: ChilliCream/hotchocolate
+tags:
+  - tools-and-libraries
+  - tools
+  - monitoring
+  - federation
+  - security
+---

--- a/src/code/services/nitro.md
+++ b/src/code/services/nitro.md
@@ -2,7 +2,7 @@
 name: Nitro
 description: A GraphQL API management platform by [ChilliCream](https://chillicream.com/?utm_source=graphql_org&utm_medium=referral) that lets you explore, test, and monitor your APIs. It includes schema and client registries, telemetry, federation support, and a full-featured GraphQL IDE.
 url: https://get-nitro.chillicream.com/?utm_source=graphql_org&utm_medium=referral
-github: ChilliCream/hotchocolate
+github: ChilliCream/graphql-platform
 tags:
   - tools-and-libraries
   - tools


### PR DESCRIPTION
## Description

ChilliCream has rebranded its GraphQL IDE "Banana Cake Pop" to "Nitro". This PR updates the corresponding entry on the tools-and-libraries page:

- Renames `bananacakepop.md` to `nitro.md` and updates the name to "Nitro"
- Updates the description to reflect that Nitro is now a GraphQL API management platform, including schema and client registries, telemetry, federation support, and the GraphQL IDE
- Updates the URL to the new product page
- Adds the `monitoring`, `federation`, and `security` tags
