### PR TITLE
Add GraphQL & AI subpage (/ai) with interactive demos

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "rss": "1.2.2",
     "scroll-into-view-if-needed": "^3.1.0",
     "server-only": "0.0.1",
+    "sharp": "^0.34.5",
     "string-similarity": "^4.0.4",
     "string-strip-html": "^13.4.8",
     "tailwindcss": "^3.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 15.5.9
       '@plaiceholder/next':
         specifier: ^3.0.0
-        version: 3.0.0(next@14.2.35(@babel/core@7.28.3)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(plaiceholder@3.0.0(sharp@0.34.4))(sharp@0.34.4)
+        version: 3.0.0(next@14.2.35(@babel/core@7.28.3)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(plaiceholder@3.0.0(sharp@0.34.5))(sharp@0.34.5)
       '@sparticuz/chromium':
         specifier: ^138.0.2
         version: 138.0.2
@@ -163,7 +163,7 @@ importers:
         version: 1.6.4
       plaiceholder:
         specifier: ^3.0.0
-        version: 3.0.0(sharp@0.34.4)
+        version: 3.0.0(sharp@0.34.5)
       playwright-core:
         specifier: ^1.54.2
         version: 1.57.0
@@ -200,6 +200,9 @@ importers:
       server-only:
         specifier: 0.0.1
         version: 0.0.1
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       string-similarity:
         specifier: ^4.0.4
         version: 4.0.4
@@ -1606,124 +1609,135 @@ packages:
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.4':
-    resolution: {integrity: sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==}
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.4':
-    resolution: {integrity: sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.3':
-    resolution: {integrity: sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.3':
-    resolution: {integrity: sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.3':
-    resolution: {integrity: sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.2.3':
-    resolution: {integrity: sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.3':
-    resolution: {integrity: sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==}
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.2.3':
-    resolution: {integrity: sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==}
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.2.3':
-    resolution: {integrity: sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
-    resolution: {integrity: sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.3':
-    resolution: {integrity: sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.34.4':
-    resolution: {integrity: sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.34.4':
-    resolution: {integrity: sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-ppc64@0.34.4':
-    resolution: {integrity: sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==}
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.34.4':
-    resolution: {integrity: sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==}
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.34.4':
-    resolution: {integrity: sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.34.4':
-    resolution: {integrity: sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.34.4':
-    resolution: {integrity: sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.34.4':
-    resolution: {integrity: sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==}
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.4':
-    resolution: {integrity: sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.4':
-    resolution: {integrity: sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==}
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.4':
-    resolution: {integrity: sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==}
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -5897,8 +5911,8 @@ packages:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
 
-  sharp@0.34.4:
-    resolution: {integrity: sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==}
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
@@ -8403,90 +8417,98 @@ snapshots:
 
   '@img/colour@1.0.0': {}
 
-  '@img/sharp-darwin-arm64@0.34.4':
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.3
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.4':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.3
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.3':
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.2.3':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.3':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.2.3':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.3':
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.3':
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.2.3':
+  '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.3':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.4':
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.3
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.34.4':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.3
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-ppc64@0.34.4':
+  '@img/sharp-linux-ppc64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.3
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.4':
+  '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.3
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.34.4':
+  '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.3
+      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.4':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.3
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.4':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.34.4':
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
     dependencies:
       '@emnapi/runtime': 1.8.1
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.4':
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.4':
+  '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.4':
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@inquirer/ansi@1.0.1': {}
@@ -8819,7 +8841,7 @@ snapshots:
       ini: 4.1.3
       nopt: 7.2.1
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.7.3
       walk-up-path: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -8833,7 +8855,7 @@ snapshots:
       proc-log: 4.2.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.7.2
+      semver: 7.7.3
       which: 4.0.0
     transitivePeerDependencies:
       - bluebird
@@ -8855,7 +8877,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       normalize-package-data: 6.0.2
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - bluebird
 
@@ -8868,11 +8890,11 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@plaiceholder/next@3.0.0(next@14.2.35(@babel/core@7.28.3)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(plaiceholder@3.0.0(sharp@0.34.4))(sharp@0.34.4)':
+  '@plaiceholder/next@3.0.0(next@14.2.35(@babel/core@7.28.3)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(plaiceholder@3.0.0(sharp@0.34.5))(sharp@0.34.5)':
     dependencies:
       next: 14.2.35(@babel/core@7.28.3)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      plaiceholder: 3.0.0(sharp@0.34.4)
-      sharp: 0.34.4
+      plaiceholder: 3.0.0(sharp@0.34.5)
+      sharp: 0.34.5
 
   '@playwright/test@1.57.0':
     dependencies:
@@ -9825,7 +9847,7 @@ snapshots:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   character-entities-html4@2.1.0: {}
 
@@ -11481,7 +11503,7 @@ snapshots:
 
   is-lower-case@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   is-map@2.0.3: {}
 
@@ -11548,7 +11570,7 @@ snapshots:
 
   is-upper-case@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   is-weakmap@2.0.2: {}
 
@@ -11804,7 +11826,7 @@ snapshots:
 
   lower-case-first@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   lower-case@2.0.2:
     dependencies:
@@ -12599,7 +12621,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.2
+      semver: 7.7.3
       validate-npm-package-license: 3.0.4
 
   normalize-path@2.1.1:
@@ -12610,7 +12632,7 @@ snapshots:
 
   npm-install-checks@6.3.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.3
 
   npm-normalize-package-bin@3.0.1: {}
 
@@ -12618,7 +12640,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.7.3
       validate-npm-package-name: 5.0.1
 
   npm-pick-manifest@9.1.0:
@@ -12626,7 +12648,7 @@ snapshots:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 11.0.3
-      semver: 7.7.2
+      semver: 7.7.3
 
   npm-run-path@5.3.0:
     dependencies:
@@ -12878,9 +12900,9 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
-  plaiceholder@3.0.0(sharp@0.34.4):
+  plaiceholder@3.0.0(sharp@0.34.5):
     dependencies:
-      sharp: 0.34.4
+      sharp: 0.34.5
 
   playwright-core@1.57.0: {}
 
@@ -13521,34 +13543,36 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
-  sharp@0.34.4:
+  sharp@0.34.5:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
       semver: 7.7.3
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.4
-      '@img/sharp-darwin-x64': 0.34.4
-      '@img/sharp-libvips-darwin-arm64': 1.2.3
-      '@img/sharp-libvips-darwin-x64': 1.2.3
-      '@img/sharp-libvips-linux-arm': 1.2.3
-      '@img/sharp-libvips-linux-arm64': 1.2.3
-      '@img/sharp-libvips-linux-ppc64': 1.2.3
-      '@img/sharp-libvips-linux-s390x': 1.2.3
-      '@img/sharp-libvips-linux-x64': 1.2.3
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.3
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.3
-      '@img/sharp-linux-arm': 0.34.4
-      '@img/sharp-linux-arm64': 0.34.4
-      '@img/sharp-linux-ppc64': 0.34.4
-      '@img/sharp-linux-s390x': 0.34.4
-      '@img/sharp-linux-x64': 0.34.4
-      '@img/sharp-linuxmusl-arm64': 0.34.4
-      '@img/sharp-linuxmusl-x64': 0.34.4
-      '@img/sharp-wasm32': 0.34.4
-      '@img/sharp-win32-arm64': 0.34.4
-      '@img/sharp-win32-ia32': 0.34.4
-      '@img/sharp-win32-x64': 0.34.4
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -13652,7 +13676,7 @@ snapshots:
 
   sponge-case@1.0.1:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   sprintf-js@1.0.3: {}
 
@@ -13840,7 +13864,7 @@ snapshots:
 
   swap-case@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   symbol-tree@3.2.4: {}
 
@@ -13933,7 +13957,7 @@ snapshots:
 
   title-case@3.0.3:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   title@4.0.1:
     dependencies:
@@ -14234,11 +14258,11 @@ snapshots:
 
   upper-case-first@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   upper-case@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   uri-js@4.4.1:
     dependencies:

--- a/src/app/(main)/ai/components/by-the-numbers.tsx
+++ b/src/app/(main)/ai/components/by-the-numbers.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { SectionLabel } from "@/app/conf/_design-system/section-label"
+import ArrowUpIcon from "@/app/conf/_design-system/pixelarticons/arrow-down.svg?svgr"
+
+const stats = [
+  {
+    label: "Token reduction",
+    graphQL: "90%",
+    graphQLDesc: "fewer tokens",
+    rest: "10× more",
+    restDesc: "token waste",
+    explanation:
+      "GraphQL lets AI agents request only the fields they need. REST endpoints return fixed payloads — often 10x the data an LLM actually needs to process. Every extra token costs money and context window space.",
+  },
+  {
+    label: "API calls per task",
+    graphQL: "1",
+    graphQLDesc: "single request",
+    rest: "3–7",
+    restDesc: "sequential calls",
+    explanation:
+      "GraphQL's composability means agents can fetch nested, related data in one query. REST requires multiple endpoints, forcing agents to make sequential calls and stitch responses client-side.",
+  },
+  {
+    label: "Tool definitions",
+    graphQL: "0",
+    graphQLDesc: "auto-discovered",
+    rest: "manual",
+    restDesc: "per endpoint",
+    explanation:
+      "Every GraphQL API includes built-in introspection. Agents can discover available types, fields, and arguments automatically. REST tool calling requires hand-crafted JSON Schema definitions for every endpoint.",
+  },
+  {
+    label: "Type safety",
+    graphQL: "100%",
+    graphQLDesc: "typed responses",
+    rest: "ad-hoc",
+    restDesc: "no guarantees",
+    explanation:
+      "GraphQL responses match the query shape exactly — validated against the schema at runtime. REST responses offer no structural guarantees, forcing LLMs to handle arbitrary JSON shapes.",
+  },
+]
+
+export function ByTheNumbers() {
+  return (
+    <section className="gql-container gql-section lg:py-16 xl:py-24">
+      <SectionLabel className="mb-6">By the numbers</SectionLabel>
+      <h2 className="typography-h2 mb-2 lg:mb-4">
+        GraphQL vs REST for AI
+      </h2>
+      <p className="typography-body-lg mb-8 max-w-2xl text-pretty text-neu-800 lg:mb-16">
+        When AI agents interact with APIs, the protocol matters. Here&apos;s
+        how GraphQL compares to traditional REST APIs across the metrics that
+        directly impact LLM efficiency and accuracy.
+      </p>
+
+      <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+        {stats.map(stat => (
+          <StatCard key={stat.label} stat={stat} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function StatCard({
+  stat,
+}: {
+  stat: (typeof stats)[number]
+}) {
+  const [animated, setAnimated] = useState(false)
+  const [gqlCount, setGqlCount] = useState(0)
+  const [restCount, setRestCount] = useState(0)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setAnimated(true)
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.3 },
+    )
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (!animated) return
+
+    const gqlTarget =
+      stat.graphQL === "90%" ? 90 : stat.graphQL === "0" ? 0 : stat.graphQL === "100%" ? 100 : parseInt(stat.graphQL) || 1
+    const restTarget =
+      stat.rest === "10× more" ? 10 : stat.rest === "3–7" ? 5 : stat.rest === "manual" ? 1 : stat.rest === "ad-hoc" ? 0 : parseInt(stat.rest) || 0
+
+    const gqlMax = Math.max(gqlTarget, 1)
+    const restMax = Math.max(restTarget, 1)
+
+    const duration = 1200
+    const start = performance.now()
+
+    function tick(now: number) {
+      const elapsed = now - start
+      const progress = Math.min(elapsed / duration, 1)
+      const eased = 1 - Math.pow(1 - progress, 3)
+
+      setGqlCount(Math.round(gqlTarget * eased))
+      setRestCount(Math.round(restMax * eased))
+
+      if (progress < 1) requestAnimationFrame(tick)
+    }
+
+    requestAnimationFrame(tick)
+  }, [animated, stat.graphQL, stat.rest])
+
+  return (
+    <div
+      ref={ref}
+      className="group rounded-xl border border-neu-200 bg-neu-0 p-6 transition-shadow hover:shadow-md dark:border-neu-100 lg:p-7"
+    >
+      <h3 className="typography-h4 text-center">{stat.label}</h3>
+
+      <div className="mt-6 grid grid-cols-2 gap-4">
+        {/* GraphQL side */}
+        <div className="text-center">
+          <p className="typography-body-xs font-medium uppercase tracking-wider text-neu-500">
+            GraphQL
+          </p>
+          <p className="typography-d1 mt-1 font-bold leading-none text-sec-dark">
+            {animated ? gqlCount : 0}
+            {stat.graphQL === "90%" || stat.graphQL === "100%" ? "%" : stat.graphQL === "0" ? "" : ""}
+          </p>
+          <p className="typography-body-xs mt-1 text-neu-600">
+            {stat.graphQLDesc}
+          </p>
+        </div>
+
+        {/* REST side */}
+        <div className="text-center">
+          <p className="typography-body-xs font-medium uppercase tracking-wider text-neu-500">
+            REST
+          </p>
+          <p className="typography-d1 mt-1 font-bold leading-none text-neu-400">
+            {animated ? restCount : 0}
+            {stat.rest === "10× more" ? "×" : stat.rest === "manual" ? "" : stat.rest === "3–7" ? "" : stat.rest === "ad-hoc" ? "" : ""}
+          </p>
+          <p className="typography-body-xs mt-1 text-neu-500">
+            {stat.restDesc}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-neu-100 dark:bg-neu-100/80">
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-sec-base to-sec-dark transition-all duration-1000 ease-out"
+          style={{
+            width: animated
+              ? stat.graphQL === "90%"
+                ? "90%"
+                : stat.graphQL === "0"
+                  ? "5%"
+                  : stat.graphQL === "100%"
+                    ? "95%"
+                    : "50%"
+              : "0%",
+          }}
+        />
+      </div>
+
+      <p className="typography-body-sm mt-4 text-pretty text-neu-700">
+        <span className="font-medium text-neu-900">Why: </span>
+        {stat.explanation}
+      </p>
+
+      {/* Advantage callout */}
+      <div className="mt-4 flex items-center gap-1.5 rounded-lg bg-sec-light/20 px-3 py-2 dark:bg-sec-darker/20">
+        <ArrowUpIcon className="size-3.5 shrink-0 rotate-180 text-sec-dark" />
+        <span className="typography-body-xs font-medium text-sec-dark">
+          GraphQL advantage: {stat.graphQL === "90%" ? "~10× token savings" : stat.graphQL === "1" ? "single round-trip" : stat.graphQL === "0" ? "zero-config" : "guaranteed types"}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/ai/components/by-the-numbers.tsx
+++ b/src/app/(main)/ai/components/by-the-numbers.tsx
@@ -47,12 +47,10 @@ export function ByTheNumbers() {
   return (
     <section className="gql-container gql-section lg:py-16 xl:py-24">
       <SectionLabel className="mb-6">By the numbers</SectionLabel>
-      <h2 className="typography-h2 mb-2 lg:mb-4">
-        GraphQL vs REST for AI
-      </h2>
+      <h2 className="typography-h2 mb-2 lg:mb-4">GraphQL vs REST for AI</h2>
       <p className="typography-body-lg mb-8 max-w-2xl text-pretty text-neu-800 lg:mb-16">
-        When AI agents interact with APIs, the protocol matters. Here&apos;s
-        how GraphQL compares to traditional REST APIs across the metrics that
+        When AI agents interact with APIs, the protocol matters. Here&apos;s how
+        GraphQL compares to traditional REST APIs across the metrics that
         directly impact LLM efficiency and accuracy.
       </p>
 
@@ -65,11 +63,7 @@ export function ByTheNumbers() {
   )
 }
 
-function StatCard({
-  stat,
-}: {
-  stat: (typeof stats)[number]
-}) {
+function StatCard({ stat }: { stat: (typeof stats)[number] }) {
   const [animated, setAnimated] = useState(false)
   const [gqlCount, setGqlCount] = useState(0)
   const [restCount, setRestCount] = useState(0)
@@ -97,9 +91,23 @@ function StatCard({
     if (!animated) return
 
     const gqlTarget =
-      stat.graphQL === "90%" ? 90 : stat.graphQL === "0" ? 0 : stat.graphQL === "100%" ? 100 : parseInt(stat.graphQL) || 1
+      stat.graphQL === "90%"
+        ? 90
+        : stat.graphQL === "0"
+          ? 0
+          : stat.graphQL === "100%"
+            ? 100
+            : parseInt(stat.graphQL) || 1
     const restTarget =
-      stat.rest === "10× more" ? 10 : stat.rest === "3–7" ? 5 : stat.rest === "manual" ? 1 : stat.rest === "ad-hoc" ? 0 : parseInt(stat.rest) || 0
+      stat.rest === "10× more"
+        ? 10
+        : stat.rest === "3–7"
+          ? 5
+          : stat.rest === "manual"
+            ? 1
+            : stat.rest === "ad-hoc"
+              ? 0
+              : parseInt(stat.rest) || 0
 
     const gqlMax = Math.max(gqlTarget, 1)
     const restMax = Math.max(restTarget, 1)
@@ -136,7 +144,11 @@ function StatCard({
           </p>
           <p className="typography-d1 mt-1 font-bold leading-none text-sec-dark">
             {animated ? gqlCount : 0}
-            {stat.graphQL === "90%" || stat.graphQL === "100%" ? "%" : stat.graphQL === "0" ? "" : ""}
+            {stat.graphQL === "90%" || stat.graphQL === "100%"
+              ? "%"
+              : stat.graphQL === "0"
+                ? ""
+                : ""}
           </p>
           <p className="typography-body-xs mt-1 text-neu-600">
             {stat.graphQLDesc}
@@ -150,7 +162,15 @@ function StatCard({
           </p>
           <p className="typography-d1 mt-1 font-bold leading-none text-neu-400">
             {animated ? restCount : 0}
-            {stat.rest === "10× more" ? "×" : stat.rest === "manual" ? "" : stat.rest === "3–7" ? "" : stat.rest === "ad-hoc" ? "" : ""}
+            {stat.rest === "10× more"
+              ? "×"
+              : stat.rest === "manual"
+                ? ""
+                : stat.rest === "3–7"
+                  ? ""
+                  : stat.rest === "ad-hoc"
+                    ? ""
+                    : ""}
           </p>
           <p className="typography-body-xs mt-1 text-neu-500">
             {stat.restDesc}
@@ -184,7 +204,14 @@ function StatCard({
       <div className="mt-4 flex items-center gap-1.5 rounded-lg bg-sec-light/20 px-3 py-2 dark:bg-sec-darker/20">
         <ArrowUpIcon className="size-3.5 shrink-0 rotate-180 text-sec-dark" />
         <span className="typography-body-xs font-medium text-sec-dark">
-          GraphQL advantage: {stat.graphQL === "90%" ? "~10× token savings" : stat.graphQL === "1" ? "single round-trip" : stat.graphQL === "0" ? "zero-config" : "guaranteed types"}
+          GraphQL advantage:{" "}
+          {stat.graphQL === "90%"
+            ? "~10× token savings"
+            : stat.graphQL === "1"
+              ? "single round-trip"
+              : stat.graphQL === "0"
+                ? "zero-config"
+                : "guaranteed types"}
         </span>
       </div>
     </div>

--- a/src/app/(main)/ai/components/by-the-numbers.tsx
+++ b/src/app/(main)/ai/components/by-the-numbers.tsx
@@ -27,19 +27,19 @@ const stats = [
     label: "Tool definitions",
     graphQL: "0",
     graphQLDesc: "auto-discovered",
-    rest: "manual",
-    restDesc: "per endpoint",
+    rest: "3",
+    restDesc: "files to wire",
     explanation:
-      "Every GraphQL API includes built-in introspection. Agents can discover available types, fields, and arguments automatically. REST tool calling requires hand-crafted JSON Schema definitions for every endpoint.",
+      "REST frameworks can auto-generate OpenAPI, so this isn't about hand-writing schemas. The edge is plug-and-play: GraphQL's introspection and per-field, per-type, and per-query documentation are built into the spec and discoverable from one endpoint. With REST, an agent needs the API, its schema, and an instruction file (AGENT.md) — and you must point it to each. One GraphQL schema replaces all three.",
   },
   {
     label: "Type safety",
     graphQL: "100%",
     graphQLDesc: "typed responses",
-    rest: "ad-hoc",
-    restDesc: "no guarantees",
+    rest: "100%",
+    restDesc: "via OpenAPI",
     explanation:
-      "GraphQL responses match the query shape exactly — validated against the schema at runtime. REST responses offer no structural guarantees, forcing LLMs to handle arbitrary JSON shapes.",
+      "Both are typed — OpenAPI gives REST schemas too. The real difference for agents is traversal: one GraphQL query follows relationships across types, so an agent never needs to hold the entire type graph in context at once. REST splits data across endpoints, forcing agents to remember deep, nested relationships to compose what one field resolves.",
   },
 ]
 
@@ -103,10 +103,10 @@ function StatCard({ stat }: { stat: (typeof stats)[number] }) {
         ? 10
         : stat.rest === "3–7"
           ? 5
-          : stat.rest === "manual"
-            ? 1
-            : stat.rest === "ad-hoc"
-              ? 0
+          : stat.rest === "3"
+            ? 3
+            : stat.rest === "100%"
+              ? 100
               : parseInt(stat.rest) || 0
 
     const gqlMax = Math.max(gqlTarget, 1)
@@ -164,12 +164,12 @@ function StatCard({ stat }: { stat: (typeof stats)[number] }) {
             {animated ? restCount : 0}
             {stat.rest === "10× more"
               ? "×"
-              : stat.rest === "manual"
+              : stat.rest === "3"
                 ? ""
                 : stat.rest === "3–7"
                   ? ""
-                  : stat.rest === "ad-hoc"
-                    ? ""
+                  : stat.rest === "100%"
+                    ? "%"
                     : ""}
           </p>
           <p className="typography-body-xs mt-1 text-neu-500">
@@ -211,7 +211,7 @@ function StatCard({ stat }: { stat: (typeof stats)[number] }) {
               ? "single round-trip"
               : stat.graphQL === "0"
                 ? "zero-config"
-                : "guaranteed types"}
+                : "graph traversal"}
         </span>
       </div>
     </div>

--- a/src/app/(main)/ai/components/by-the-numbers.tsx
+++ b/src/app/(main)/ai/components/by-the-numbers.tsx
@@ -1,8 +1,50 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
 import { SectionLabel } from "@/app/conf/_design-system/section-label"
-import ArrowUpIcon from "@/app/conf/_design-system/pixelarticons/arrow-down.svg?svgr"
+import {
+  highlightGraphQLSchema,
+  highlightGraphQL,
+  highlightJSON,
+  SYNTAX_CSS,
+} from "./syntax-highlight"
+
+const schemaWithDocs = `"""A product in the catalog."""
+type Product {
+  """Human-readable display name."""
+  name: String!
+
+  """Price in minor units (cents)."""
+  price: Int!
+
+  """Units in stock. 0 means unavailable."""
+  stock: Int!
+}
+
+type Query {
+  """Full-text search across the catalog."""
+  products(query: String!): [Product!]!
+}`
+
+const introspectionQuery = `{
+  __type(name: "Product") {
+    description
+    fields {
+      name
+      description
+    }
+  }
+}`
+
+const introspectionResponse = `{
+  "__type": {
+    "description": "A product in the catalog.",
+    "fields": [
+      { "name": "name",  "description": "Human-readable display name." },
+      { "name": "price", "description": "Price in minor units (cents)." },
+      { "name": "stock", "description": "Units in stock. 0 means unavailable." }
+    ]
+  }
+}`
 
 const stats = [
   {
@@ -37,7 +79,7 @@ const stats = [
     graphQL: "100%",
     graphQLDesc: "typed responses",
     rest: "100%",
-    restDesc: "via OpenAPI",
+    restDesc: "if used with correct tooling",
     explanation:
       "Both are typed — OpenAPI gives REST schemas too. The real difference for agents is traversal: one GraphQL query follows relationships across types, so an agent never needs to hold the entire type graph in context at once. REST splits data across endpoints, forcing agents to remember deep, nested relationships to compose what one field resolves.",
   },
@@ -45,175 +87,160 @@ const stats = [
 
 export function ByTheNumbers() {
   return (
-    <section className="gql-container gql-section lg:py-16 xl:py-24">
+    <section className="gql-container gql-section lg:py-12 xl:py-16">
       <SectionLabel className="mb-6">By the numbers</SectionLabel>
       <h2 className="typography-h2 mb-2 lg:mb-4">GraphQL vs REST for AI</h2>
-      <p className="typography-body-lg mb-8 max-w-2xl text-pretty text-neu-800 lg:mb-16">
-        When AI agents interact with APIs, the protocol matters. Here&apos;s how
-        GraphQL compares to traditional REST APIs across the metrics that
-        directly impact LLM efficiency and accuracy.
+      <p className="typography-body-lg mb-6 max-w-2xl text-pretty text-neu-800">
+        Where GraphQL pays off when AI agents talk to your API.
+      </p>
+      {/* Mobile: compact stacked panels */}
+      <div className="md:hidden">
+        {stats.map(stat => (
+          <div
+            key={stat.label}
+            className="border-b border-neu-200 py-3 last:border-b-0 dark:border-neu-100"
+          >
+            <p className="typography-body-sm font-medium text-neu-900">
+              {stat.label}
+            </p>
+            <div className="mt-1 flex items-baseline gap-3">
+              <span className="typography-body-sm font-medium text-sec-dark">
+                {stat.graphQL}{" "}
+                <span className="typography-body-xs text-neu-600">
+                  {stat.graphQLDesc}
+                </span>
+              </span>
+              <span className="typography-body-xs text-neu-400">vs</span>
+              <span className="typography-body-sm text-neu-500">
+                {stat.rest}{" "}
+                <span className="typography-body-xs text-neu-400">
+                  {stat.restDesc}
+                </span>
+              </span>
+            </div>
+            <p className="typography-body-xs mt-1 text-pretty text-neu-600">
+              {stat.explanation}
+            </p>
+          </div>
+        ))}
+      </div>
+      {/* Desktop: table */}
+      <div className="hidden overflow-x-auto md:block">
+        <table className="w-full border-collapse text-left">
+          <thead>
+            <tr className="border-b border-neu-200 dark:border-neu-100">
+              <th className="typography-body-xs px-4 py-3 font-medium uppercase tracking-wider text-neu-500">
+                Metric
+              </th>
+              <th className="typography-body-xs px-4 py-3 font-medium uppercase tracking-wider text-sec-dark">
+                GraphQL
+              </th>
+              <th className="typography-body-xs px-4 py-3 font-medium uppercase tracking-wider text-neu-500">
+                REST
+              </th>
+              <th className="typography-body-xs px-4 py-3 font-medium uppercase tracking-wider text-neu-500">
+                Why
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {stats.map(stat => (
+              <tr
+                key={stat.label}
+                className="border-b border-neu-200 align-top dark:border-neu-100"
+              >
+                <th
+                  scope="row"
+                  className="typography-body-sm whitespace-nowrap px-4 py-3 font-medium text-neu-900"
+                >
+                  {stat.label}
+                </th>
+                <td className="typography-body-sm whitespace-nowrap px-4 py-3 font-medium text-sec-dark">
+                  {stat.graphQL}
+                  <span className="typography-body-xs mt-0.5 block text-neu-600">
+                    {stat.graphQLDesc}
+                  </span>
+                </td>
+                <td className="typography-body-sm whitespace-nowrap px-4 py-3 text-neu-500">
+                  {stat.rest}
+                  <span className="typography-body-xs mt-0.5 block text-neu-400">
+                    {stat.restDesc}
+                  </span>
+                </td>
+                <td className="typography-body-sm text-pretty px-4 py-3 text-neu-700">
+                  {stat.explanation}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="typography-body-xs mt-3 text-neu-500">
+        Both protocols are typed; the gap is in traversal and discoverability,
+        not in whether types exist.
       </p>
 
-      <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
-        {stats.map(stat => (
-          <StatCard key={stat.label} stat={stat} />
-        ))}
+      {/* Documentation is part of the schema, queryable via introspection */}
+      <div className="mt-10">
+        <h3 className="typography-h3 mb-2">
+          Docs live in the schema — and agents can query them
+        </h3>
+        <p className="typography-body-md mb-6 max-w-3xl text-pretty text-neu-700">
+          Descriptions written with{" "}
+          <code className="rounded bg-neu-100 px-1 py-0.5 font-mono text-sm text-neu-800 dark:bg-neu-100/80">
+            """
+          </code>{" "}
+          are stored on the type and every field. An agent reads them back with
+          the built-in{" "}
+          <code className="rounded bg-neu-100 px-1 py-0.5 font-mono text-sm text-neu-800 dark:bg-neu-100/80">
+            __type
+          </code>{" "}
+          introspection query — no separate docs file or AGENT.md to point it
+          to.
+        </p>
+        <style dangerouslySetInnerHTML={{ __html: SYNTAX_CSS }} />
+        <div className="grid gap-px overflow-hidden rounded-xl border border-neu-200 bg-neu-200 dark:border-neu-100 dark:bg-neu-100 lg:grid-cols-3">
+          <CodePane
+            label="Schema (with embedded docs)"
+            code={schemaWithDocs}
+            highlight={highlightGraphQLSchema}
+          />
+          <CodePane
+            label="Introspection query"
+            code={introspectionQuery}
+            highlight={highlightGraphQL}
+          />
+          <CodePane
+            label="Response (docs returned)"
+            code={introspectionResponse}
+            highlight={highlightJSON}
+          />
+        </div>
       </div>
     </section>
   )
 }
 
-function StatCard({ stat }: { stat: (typeof stats)[number] }) {
-  const [animated, setAnimated] = useState(false)
-  const [gqlCount, setGqlCount] = useState(0)
-  const [restCount, setRestCount] = useState(0)
-  const ref = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setAnimated(true)
-          observer.disconnect()
-        }
-      },
-      { threshold: 0.3 },
-    )
-
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [])
-
-  useEffect(() => {
-    if (!animated) return
-
-    const gqlTarget =
-      stat.graphQL === "90%"
-        ? 90
-        : stat.graphQL === "0"
-          ? 0
-          : stat.graphQL === "100%"
-            ? 100
-            : parseInt(stat.graphQL) || 1
-    const restTarget =
-      stat.rest === "10× more"
-        ? 10
-        : stat.rest === "3–7"
-          ? 5
-          : stat.rest === "3"
-            ? 3
-            : stat.rest === "100%"
-              ? 100
-              : parseInt(stat.rest) || 0
-
-    const gqlMax = Math.max(gqlTarget, 1)
-    const restMax = Math.max(restTarget, 1)
-
-    const duration = 1200
-    const start = performance.now()
-
-    function tick(now: number) {
-      const elapsed = now - start
-      const progress = Math.min(elapsed / duration, 1)
-      const eased = 1 - Math.pow(1 - progress, 3)
-
-      setGqlCount(Math.round(gqlTarget * eased))
-      setRestCount(Math.round(restMax * eased))
-
-      if (progress < 1) requestAnimationFrame(tick)
-    }
-
-    requestAnimationFrame(tick)
-  }, [animated, stat.graphQL, stat.rest])
-
+function CodePane({
+  label,
+  code,
+  highlight,
+}: {
+  label: string
+  code: string
+  highlight: (source: string) => string
+}) {
   return (
-    <div
-      ref={ref}
-      className="group rounded-xl border border-neu-200 bg-neu-0 p-6 transition-shadow hover:shadow-md dark:border-neu-100 lg:p-7"
-    >
-      <h3 className="typography-h4 text-center">{stat.label}</h3>
-
-      <div className="mt-6 grid grid-cols-2 gap-4">
-        {/* GraphQL side */}
-        <div className="text-center">
-          <p className="typography-body-xs font-medium uppercase tracking-wider text-neu-500">
-            GraphQL
-          </p>
-          <p className="typography-d1 mt-1 font-bold leading-none text-sec-dark">
-            {animated ? gqlCount : 0}
-            {stat.graphQL === "90%" || stat.graphQL === "100%"
-              ? "%"
-              : stat.graphQL === "0"
-                ? ""
-                : ""}
-          </p>
-          <p className="typography-body-xs mt-1 text-neu-600">
-            {stat.graphQLDesc}
-          </p>
-        </div>
-
-        {/* REST side */}
-        <div className="text-center">
-          <p className="typography-body-xs font-medium uppercase tracking-wider text-neu-500">
-            REST
-          </p>
-          <p className="typography-d1 mt-1 font-bold leading-none text-neu-400">
-            {animated ? restCount : 0}
-            {stat.rest === "10× more"
-              ? "×"
-              : stat.rest === "3"
-                ? ""
-                : stat.rest === "3–7"
-                  ? ""
-                  : stat.rest === "100%"
-                    ? "%"
-                    : ""}
-          </p>
-          <p className="typography-body-xs mt-1 text-neu-500">
-            {stat.restDesc}
-          </p>
-        </div>
+    <div className="bg-[#1e1e2e]">
+      <div className="border-b border-neu-100/10 px-3 py-1.5">
+        <span className="font-mono text-[11px] text-[#6c7086]">{label}</span>
       </div>
-
-      <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-neu-100 dark:bg-neu-100/80">
-        <div
-          className="h-full rounded-full bg-gradient-to-r from-sec-base to-sec-dark transition-all duration-1000 ease-out"
-          style={{
-            width: animated
-              ? stat.graphQL === "90%"
-                ? "90%"
-                : stat.graphQL === "0"
-                  ? "5%"
-                  : stat.graphQL === "100%"
-                    ? "95%"
-                    : "50%"
-              : "0%",
-          }}
+      <pre className="overflow-x-auto p-3 font-mono text-[11px] leading-relaxed">
+        <code
+          className="whitespace-pre-wrap"
+          dangerouslySetInnerHTML={{ __html: highlight(code) }}
         />
-      </div>
-
-      <p className="typography-body-sm mt-4 text-pretty text-neu-700">
-        <span className="font-medium text-neu-900">Why: </span>
-        {stat.explanation}
-      </p>
-
-      {/* Advantage callout */}
-      <div className="mt-4 flex items-center gap-1.5 rounded-lg bg-sec-light/20 px-3 py-2 dark:bg-sec-darker/20">
-        <ArrowUpIcon className="size-3.5 shrink-0 rotate-180 text-sec-dark" />
-        <span className="typography-body-xs font-medium text-sec-dark">
-          GraphQL advantage:{" "}
-          {stat.graphQL === "90%"
-            ? "~10× token savings"
-            : stat.graphQL === "1"
-              ? "single round-trip"
-              : stat.graphQL === "0"
-                ? "zero-config"
-                : "graph traversal"}
-        </span>
-      </div>
+      </pre>
     </div>
   )
 }

--- a/src/app/(main)/ai/components/cta-community.tsx
+++ b/src/app/(main)/ai/components/cta-community.tsx
@@ -1,0 +1,41 @@
+import { Anchor } from "@/app/conf/_design-system/anchor"
+import ArrowDownIcon from "@/app/conf/_design-system/pixelarticons/arrow-down.svg?svgr"
+import { DiscordIcon } from "@/icons"
+
+export function CTACommunity() {
+  return (
+    <section className="gql-section max-sm:px-0 lg:pb-16 lg:max-xl:px-0 xl:pb-24">
+      <div className="gql-container typography-body-lg flex bg-pri-dark text-white dark:bg-pri-darker max-lg:flex-col">
+        <div className="border-pri-light p-6 max-lg:border-b lg:border-r lg:p-16">
+          <h2 className="typography-h2 text-balance">
+            Shape the future of
+            <br />
+            GraphQL & AI
+          </h2>
+          <p className="mt-8">
+            The GraphQL AI Working Group is open to everyone. Help define how
+            GraphQL powers the next generation of intelligent systems —
+            contribute to specs, share use cases, and collaborate with the
+            community.
+          </p>
+        </div>
+        <div className="flex flex-col *:flex-1">
+          <Anchor
+            href="https://discord.graphql.org/"
+            className="flex items-center justify-between gap-4 whitespace-pre border-b border-pri-light px-6 py-8 hover:bg-white/10 lg:h-1/2 lg:px-8 lg:pr-12 xl:gap-6"
+          >
+            Join the Discord
+            <DiscordIcon className="size-8 fill-white" />
+          </Anchor>
+          <Anchor
+            href="https://github.com/graphql/ai-wg"
+            className="flex items-center justify-between gap-4 whitespace-pre px-6 py-8 hover:bg-white/10 lg:h-1/2 lg:px-8 lg:pr-12 xl:gap-6"
+          >
+            AI Working Group on GitHub
+            <ArrowDownIcon className="size-10 -rotate-90 text-pri-light" />
+          </Anchor>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/(main)/ai/components/hero.tsx
+++ b/src/app/(main)/ai/components/hero.tsx
@@ -40,7 +40,10 @@ export function Hero() {
       <div className="gql-container relative">
         <div className="flex flex-col items-center px-4 pb-16 pt-24 text-center lg:min-h-[640px] lg:justify-center lg:pb-24 lg:pt-32 xl:min-h-[720px] xl:px-24 xl:pt-40">
           {/* Badge */}
-          <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-sec-light/30 bg-sec-light/10 px-4 py-1.5 backdrop-blur-sm">
+          <a
+            href="https://github.com/graphql/ai-wg/"
+            className="mb-8 inline-flex items-center gap-2 rounded-full border border-sec-light/30 bg-sec-light/10 px-4 py-1.5 backdrop-blur-sm transition-colors hover:bg-sec-light/20"
+          >
             <span className="relative flex size-2">
               <span className="absolute inline-flex size-2 animate-ping rounded-full bg-sec-base opacity-75" />
               <span className="relative inline-flex size-2 rounded-full bg-sec-base" />
@@ -48,7 +51,7 @@ export function Hero() {
             <span className="typography-body-sm font-medium text-sec-light">
               New: GraphQL AI Working Group
             </span>
-          </div>
+          </a>
 
           <h1 className="typography-h1 max-w-4xl text-balance">
             The API language

--- a/src/app/(main)/ai/components/hero.tsx
+++ b/src/app/(main)/ai/components/hero.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/app/conf/_design-system/button"
 import { SectionLabel } from "@/app/conf/_design-system/section-label"
 import CheckIcon from "@/app/conf/_design-system/pixelarticons/check.svg?svgr"
 import ArrowDownIcon from "@/app/conf/_design-system/pixelarticons/arrow-down.svg?svgr"
+import blurBean from "@/components/blog-page/blur-bean.webp"
 
 const highlights = [
   "Self-describing schemas let agents discover your API",
@@ -16,11 +17,26 @@ const highlights = [
 export function Hero() {
   return (
     <div className="relative overflow-hidden bg-pri-dark text-white dark:bg-pri-darker">
-      <StripesDecoration
-        stripeWidth="8px"
-        evenClassName="bg-[linear-gradient(180deg,hsl(var(--color-pri-darker)/0.6)_0%,transparent_100%)] dark:bg-[linear-gradient(180deg,hsl(var(--color-pri-light)/0.25)_0%,transparent_100%)]"
-        oddClassName="bg-[linear-gradient(180deg,hsl(var(--color-neu-900)/0.2)_0%,transparent_100%)] dark:bg-[linear-gradient(180deg,hsl(var(--color-neu-0)/0.12)_0%,transparent_100%)]"
-      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          maskImage: `url(${blurBean.src})`,
+          WebkitMaskImage: `url(${blurBean.src})`,
+          maskRepeat: "no-repeat",
+          WebkitMaskRepeat: "no-repeat",
+          maskPosition: "center top",
+          WebkitMaskPosition: "center top",
+          maskSize: "cover",
+          WebkitMaskSize: "cover",
+        }}
+      >
+        <StripesDecoration
+          stripeWidth="8px"
+          evenClassName="bg-[linear-gradient(180deg,hsl(var(--color-pri-darker)/0.6)_0%,transparent_100%)] dark:bg-[linear-gradient(180deg,hsl(var(--color-pri-light)/0.25)_0%,transparent_100%)]"
+          oddClassName="bg-[linear-gradient(180deg,hsl(var(--color-neu-900)/0.2)_0%,transparent_100%)] dark:bg-[linear-gradient(180deg,hsl(var(--color-neu-0)/0.12)_0%,transparent_100%)]"
+        />
+      </div>
       <SchemaGrid />
       <div className="gql-container relative">
         <div className="flex flex-col items-center px-4 pb-16 pt-24 text-center lg:min-h-[640px] lg:justify-center lg:pb-24 lg:pt-32 xl:min-h-[720px] xl:px-24 xl:pt-40">

--- a/src/app/(main)/ai/components/hero.tsx
+++ b/src/app/(main)/ai/components/hero.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef } from "react"
 import { StripesDecoration } from "@/app/conf/_design-system/stripes-decoration"
 import { Button } from "@/app/conf/_design-system/button"
-import { SectionLabel } from "@/app/conf/_design-system/section-label"
 import CheckIcon from "@/app/conf/_design-system/pixelarticons/check.svg?svgr"
 import ArrowDownIcon from "@/app/conf/_design-system/pixelarticons/arrow-down.svg?svgr"
 import blurBean from "@/components/blog-page/blur-bean.webp"
@@ -50,10 +49,6 @@ export function Hero() {
               New: GraphQL AI Working Group
             </span>
           </div>
-
-          <SectionLabel className="mb-6 !text-sec-light">
-            GraphQL + AI
-          </SectionLabel>
 
           <h1 className="typography-h1 max-w-4xl text-balance">
             The API protocol

--- a/src/app/(main)/ai/components/hero.tsx
+++ b/src/app/(main)/ai/components/hero.tsx
@@ -51,9 +51,9 @@ export function Hero() {
           </div>
 
           <h1 className="typography-h1 max-w-4xl text-balance">
-            The API protocol
+            The API language
             <br />
-            <span className="text-sec-light">for intelligent systems</span>
+            <span className="text-sec-light">for humans and agents</span>
           </h1>
 
           <p className="typography-body-lg mt-6 max-w-2xl text-pretty text-white/80">

--- a/src/app/(main)/ai/components/hero.tsx
+++ b/src/app/(main)/ai/components/hero.tsx
@@ -47,9 +47,9 @@ export function Hero() {
 
           <p className="typography-body-lg mt-6 max-w-2xl text-pretty text-white/80">
             When AI agents need to interact with APIs, GraphQL&apos;s
-            self-describing schemas, strong typing, and composable queries
-            make it the natural choice. No hand-written tool definitions.
-            No token-wasting REST payloads. Just structured, predictable data.
+            self-describing schemas, strong typing, and composable queries make
+            it the natural choice. No hand-written tool definitions. No
+            token-wasting REST payloads. Just structured, predictable data.
           </p>
 
           <ul className="mt-8 flex max-w-2xl flex-wrap justify-center gap-x-8 gap-y-2">
@@ -72,10 +72,7 @@ export function Hero() {
             >
               Read the blog post
             </Button>
-            <Button
-              href="/resources/ai"
-              variant="tertiary"
-            >
+            <Button href="/resources/ai" variant="tertiary">
               Explore AI resources
             </Button>
           </div>
@@ -100,7 +97,8 @@ function SchemaGrid() {
 
     let animId: number
     let time = 0
-    const nodes: { x: number; y: number; r: number; vx: number; vy: number }[] = []
+    const nodes: { x: number; y: number; r: number; vx: number; vy: number }[] =
+      []
 
     function resize() {
       if (!canvas) return

--- a/src/app/(main)/ai/components/hero.tsx
+++ b/src/app/(main)/ai/components/hero.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { StripesDecoration } from "@/app/conf/_design-system/stripes-decoration"
+import { Button } from "@/app/conf/_design-system/button"
+import { SectionLabel } from "@/app/conf/_design-system/section-label"
+import CheckIcon from "@/app/conf/_design-system/pixelarticons/check.svg?svgr"
+import ArrowDownIcon from "@/app/conf/_design-system/pixelarticons/arrow-down.svg?svgr"
+
+const highlights = [
+  "Self-describing schemas let agents discover your API",
+  "Strong typing eliminates hallucinated API calls",
+  "Composable queries minimize token usage by up to 90%",
+]
+
+export function Hero() {
+  return (
+    <div className="relative overflow-hidden bg-pri-dark text-white dark:bg-pri-darker">
+      <StripesDecoration
+        stripeWidth="8px"
+        evenClassName="bg-[linear-gradient(180deg,hsl(var(--color-pri-light)/0.15)_20%,hsl(var(--color-pri-base))_150%)]"
+        oddClassName="bg-[linear-gradient(180deg,hsl(var(--color-pri-light)/0.3)_20%,hsl(var(--color-pri-lighter)/0.6)_150%)]"
+      />
+      <SchemaGrid />
+      <div className="gql-container relative">
+        <div className="flex flex-col items-center px-4 pb-16 pt-24 text-center lg:min-h-[640px] lg:justify-center lg:pb-24 lg:pt-32 xl:min-h-[720px] xl:px-24 xl:pt-40">
+          {/* Badge */}
+          <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-sec-light/30 bg-sec-light/10 px-4 py-1.5 backdrop-blur-sm">
+            <span className="relative flex size-2">
+              <span className="absolute inline-flex size-2 animate-ping rounded-full bg-sec-base opacity-75" />
+              <span className="relative inline-flex size-2 rounded-full bg-sec-base" />
+            </span>
+            <span className="typography-body-sm font-medium text-sec-light">
+              New: GraphQL AI Working Group
+            </span>
+          </div>
+
+          <SectionLabel className="mb-6 !text-sec-light">
+            GraphQL + AI
+          </SectionLabel>
+
+          <h1 className="typography-h1 max-w-4xl text-balance">
+            The API protocol
+            <br />
+            <span className="text-sec-light">for intelligent systems</span>
+          </h1>
+
+          <p className="typography-body-lg mt-6 max-w-2xl text-pretty text-white/80">
+            When AI agents need to interact with APIs, GraphQL&apos;s
+            self-describing schemas, strong typing, and composable queries
+            make it the natural choice. No hand-written tool definitions.
+            No token-wasting REST payloads. Just structured, predictable data.
+          </p>
+
+          <ul className="mt-8 flex max-w-2xl flex-wrap justify-center gap-x-8 gap-y-2">
+            {highlights.map((item, index) => (
+              <li key={index} className="flex items-start gap-1.5">
+                <CheckIcon className="mt-0.5 size-4 shrink-0 text-sec-base" />
+                <span className="typography-body-sm text-white/80">{item}</span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+            <Button href="#interactive-demo" variant="primary">
+              Try the live demo
+              <ArrowDownIcon className="size-5 shrink-0 text-neu-0" />
+            </Button>
+            <Button
+              href="/blog/2025-07-03-graphql-supercharging-ai/"
+              variant="secondary"
+            >
+              Read the blog post
+            </Button>
+            <Button
+              href="/resources/ai"
+              variant="tertiary"
+            >
+              Explore AI resources
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ─────────────────────────────────────────────
+   Subtle animated schema grid in background
+   ───────────────────────────────────────────── */
+
+function SchemaGrid() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    let animId: number
+    let time = 0
+    const nodes: { x: number; y: number; r: number; vx: number; vy: number }[] = []
+
+    function resize() {
+      if (!canvas) return
+      canvas.width = canvas.offsetWidth * (window.devicePixelRatio || 1)
+      canvas.height = canvas.offsetHeight * (window.devicePixelRatio || 1)
+      ctx!.setTransform(1, 0, 0, 1, 0, 0)
+      ctx!.scale(window.devicePixelRatio || 1, window.devicePixelRatio || 1)
+    }
+
+    function init() {
+      resize()
+      const w = canvas!.offsetWidth
+      const h = canvas!.offsetHeight
+      nodes.length = 0
+      for (let i = 0; i < 30; i++) {
+        nodes.push({
+          x: Math.random() * w,
+          y: Math.random() * h,
+          r: Math.random() * 2 + 1,
+          vx: (Math.random() - 0.5) * 0.3,
+          vy: (Math.random() - 0.5) * 0.3,
+        })
+      }
+    }
+
+    function draw() {
+      if (!canvas || !ctx) return
+      const w = canvas.offsetWidth
+      const h = canvas.offsetHeight
+
+      ctx.clearRect(0, 0, w, h)
+      time += 0.005
+
+      // Update & draw nodes
+      for (const n of nodes) {
+        n.x += n.vx
+        n.y += n.vy + Math.sin(time + n.x * 0.02) * 0.1
+        if (n.x < 0) n.x = w
+        if (n.x > w) n.x = 0
+        if (n.y < 0) n.y = h
+        if (n.y > h) n.y = 0
+      }
+
+      // Draw connections
+      const maxDist = 150
+      for (let i = 0; i < nodes.length; i++) {
+        for (let j = i + 1; j < nodes.length; j++) {
+          const dx = nodes[i].x - nodes[j].x
+          const dy = nodes[i].y - nodes[j].y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          if (dist < maxDist) {
+            ctx.beginPath()
+            ctx.moveTo(nodes[i].x, nodes[i].y)
+            ctx.lineTo(nodes[j].x, nodes[j].y)
+            const alpha = (1 - dist / maxDist) * 0.08
+            ctx.strokeStyle = `rgba(255,204,239,${alpha})`
+            ctx.stroke()
+          }
+        }
+      }
+
+      // Draw nodes
+      for (const n of nodes) {
+        ctx.beginPath()
+        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2)
+        ctx.fillStyle = "rgba(255,204,239,0.15)"
+        ctx.fill()
+      }
+
+      animId = requestAnimationFrame(draw)
+    }
+
+    init()
+    draw()
+    window.addEventListener("resize", init)
+
+    return () => {
+      cancelAnimationFrame(animId)
+      window.removeEventListener("resize", init)
+    }
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className="pointer-events-none absolute inset-0 z-0 opacity-60"
+    />
+  )
+}

--- a/src/app/(main)/ai/components/hero.tsx
+++ b/src/app/(main)/ai/components/hero.tsx
@@ -18,8 +18,8 @@ export function Hero() {
     <div className="relative overflow-hidden bg-pri-dark text-white dark:bg-pri-darker">
       <StripesDecoration
         stripeWidth="8px"
-        evenClassName="bg-[linear-gradient(180deg,hsl(var(--color-pri-light)/0.15)_20%,hsl(var(--color-pri-base))_150%)]"
-        oddClassName="bg-[linear-gradient(180deg,hsl(var(--color-pri-light)/0.3)_20%,hsl(var(--color-pri-lighter)/0.6)_150%)]"
+        evenClassName="bg-[linear-gradient(180deg,hsl(var(--color-pri-darker)/0.6)_0%,transparent_100%)] dark:bg-[linear-gradient(180deg,hsl(var(--color-pri-light)/0.25)_0%,transparent_100%)]"
+        oddClassName="bg-[linear-gradient(180deg,hsl(var(--color-neu-900)/0.2)_0%,transparent_100%)] dark:bg-[linear-gradient(180deg,hsl(var(--color-neu-0)/0.12)_0%,transparent_100%)]"
       />
       <SchemaGrid />
       <div className="gql-container relative">

--- a/src/app/(main)/ai/components/how-it-works.tsx
+++ b/src/app/(main)/ai/components/how-it-works.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+import { SectionLabel } from "@/app/conf/_design-system/section-label"
+import SearchIcon from "@/app/conf/_design-system/pixelarticons/search.svg?svgr"
+import CodeIcon from "@/app/conf/_design-system/pixelarticons/code.svg?svgr"
+import PlayIcon from "@/app/conf/_design-system/pixelarticons/play.svg?svgr"
+import CheckIcon from "@/app/conf/_design-system/pixelarticons/check.svg?svgr"
+import { highlightGraphQL, highlightGraphQLSchema, highlightJSON, highlightPrompt, SYNTAX_CSS } from "./syntax-highlight"
+
+const steps = [
+  {
+    number: "01",
+    title: "Agent receives a task",
+    icon: PlayIcon,
+    description:
+      'A user gives an AI agent a natural language instruction — "Show me Q4 revenue by region." The agent needs to access business data through an API to fulfill this request.',
+    codeLabel: "User prompt",
+    code: `> Show me Q4 revenue broken down by region
+  for the top 5 performing product categories`,
+    highlight: highlightPrompt,
+  },
+  {
+    number: "02",
+    title: "Agent introspects the API",
+    icon: SearchIcon,
+    description:
+      'Using GraphQL introspection, the agent queries `__schema` and discovers the available types: `Product`, `Order`, `Region`, `RevenueMetrics`. It learns field names, arguments, and relationships automatically.',
+    codeLabel: "Introspection result → discovered types",
+    code: `type Product {
+  name: String!
+  category: Category!
+}
+type RevenueMetrics {
+  amount: Float!
+  region: Region!
+}
+type Order {
+  product: Product!
+  revenue: RevenueMetrics!
+}
+type Query {
+  orders(from: Date!, to: Date!): [Order!]!
+}`,
+    highlight: highlightGraphQLSchema,
+  },
+  {
+    number: "03",
+    title: "Agent composes a query",
+    icon: CodeIcon,
+    description:
+      "The LLM maps the user's intent to the discovered schema. It constructs a precise GraphQL query that fetches exactly the right data — revenue by region, top 5 categories, all in a single request — with no over-fetching.",
+    codeLabel: "AI-generated GraphQL query",
+    code: `{
+  orders(from: "2024-10-01", to: "2024-12-31") {
+    product {
+      name
+      category {
+        name
+      }
+    }
+    revenue {
+      region {
+        name
+      }
+      amount
+    }
+  }
+}`,
+    highlight: highlightGraphQL,
+  },
+  {
+    number: "04",
+    title: "Structured response returned",
+    icon: CheckIcon,
+    description:
+      "The API returns typed, predictable JSON that exactly matches the query shape. The agent processes the results with confidence — every field is validated, every type is known. No parsing ambiguity, no hallucinated or missing fields.",
+    codeLabel: "Structured response (JSON)",
+    code: `{
+  "orders": [{
+    "product": {
+      "name": "Widget Pro",
+      "category": {
+        "name": "Electronics"
+      }
+    },
+    "revenue": {
+      "region": {
+        "name": "North America"
+      },
+      "amount": 45230.50
+    }
+  }]
+}`,
+    highlight: highlightJSON,
+  },
+]
+
+export function HowItWorks() {
+  return (
+    <section className="overflow-hidden bg-neu-50 dark:bg-neu-50/25">
+      <div className="gql-container gql-section lg:py-16 xl:py-24">
+        <SectionLabel className="mb-6">How it works</SectionLabel>
+        <h2 className="typography-h2 mb-2 lg:mb-4">
+          From natural language
+          <br />
+          to structured data
+        </h2>
+        <p className="typography-body-lg mb-8 max-w-2xl text-pretty text-neu-800 lg:mb-16">
+          Here&apos;s what happens when an AI agent uses a GraphQL API to
+          answer a real business question — from initial request to typed response.
+        </p>
+
+        <style dangerouslySetInnerHTML={{ __html: SYNTAX_CSS }} />
+        <div className="grid gap-px bg-neu-200 dark:bg-neu-100 sm:grid-cols-2 lg:grid-cols-4">
+          {steps.map((step, i) => (
+            <div
+              key={step.number}
+              className="relative flex flex-col bg-neu-0 p-5 lg:p-6 xl:p-8"
+            >
+              {/* Step number + icon */}
+              <div className="flex items-center gap-3">
+                <span className="typography-d1 font-bold leading-none text-pri-base/15">
+                  {step.number}
+                </span>
+                <step.icon className="size-5 shrink-0 text-pri-base" />
+              </div>
+
+              <h3 className="typography-h4 mt-3">{step.title}</h3>
+              <p className="typography-body-sm mt-2 flex-1 text-pretty text-neu-700">
+                {step.description}
+              </p>
+
+              {/* Code snippet */}
+              <div className="mt-4 overflow-hidden rounded-lg border border-neu-200 bg-[#1e1e2e] dark:border-neu-100">
+                <div className="border-b border-neu-100/10 px-3 py-1.5">
+                  <span className="font-mono text-[11px] text-[#6c7086]">
+                    {step.codeLabel}
+                  </span>
+                </div>
+                <pre className="overflow-x-auto p-3 font-mono text-[11px] leading-relaxed">
+                  <code
+                    className="whitespace-pre-wrap"
+                    dangerouslySetInnerHTML={{
+                      __html: step.highlight(step.code),
+                    }}
+                  />
+                </pre>
+              </div>
+
+              {/* Connector arrows between steps */}
+              {i < steps.length - 1 && (
+                <>
+                  {/* Horizontal arrow for lg+ */}
+                  <div className="absolute right-0 top-10 z-10 hidden lg:flex size-6 items-center justify-center rounded-full border-2 border-neu-100 bg-neu-0 dark:border-neu-50">
+                    <svg
+                      width="10"
+                      height="10"
+                      viewBox="0 0 10 10"
+                      className="text-neu-400"
+                    >
+                      <path
+                        d="M2 2 L8 5 L2 8"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </div>
+                  {/* Dot connector for sm (2-col) */}
+                  <div className="absolute right-0 top-1/2 z-10 hidden size-2 -translate-y-1/2 translate-x-1/2 rounded-full border border-neu-200 bg-neu-0 sm:block lg:hidden" />
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/(main)/ai/components/how-it-works.tsx
+++ b/src/app/(main)/ai/components/how-it-works.tsx
@@ -5,7 +5,13 @@ import SearchIcon from "@/app/conf/_design-system/pixelarticons/search.svg?svgr"
 import CodeIcon from "@/app/conf/_design-system/pixelarticons/code.svg?svgr"
 import PlayIcon from "@/app/conf/_design-system/pixelarticons/play.svg?svgr"
 import CheckIcon from "@/app/conf/_design-system/pixelarticons/check.svg?svgr"
-import { highlightGraphQL, highlightGraphQLSchema, highlightJSON, highlightPrompt, SYNTAX_CSS } from "./syntax-highlight"
+import {
+  highlightGraphQL,
+  highlightGraphQLSchema,
+  highlightJSON,
+  highlightPrompt,
+  SYNTAX_CSS,
+} from "./syntax-highlight"
 
 const steps = [
   {
@@ -24,7 +30,7 @@ const steps = [
     title: "Agent introspects the API",
     icon: SearchIcon,
     description:
-      'Using GraphQL introspection, the agent queries `__schema` and discovers the available types: `Product`, `Order`, `Region`, `RevenueMetrics`. It learns field names, arguments, and relationships automatically.',
+      "Using GraphQL introspection, the agent queries `__schema` and discovers the available types: `Product`, `Order`, `Region`, `RevenueMetrics`. It learns field names, arguments, and relationships automatically.",
     codeLabel: "Introspection result → discovered types",
     code: `type Product {
   name: String!
@@ -106,8 +112,8 @@ export function HowItWorks() {
           to structured data
         </h2>
         <p className="typography-body-lg mb-8 max-w-2xl text-pretty text-neu-800 lg:mb-16">
-          Here&apos;s what happens when an AI agent uses a GraphQL API to
-          answer a real business question — from initial request to typed response.
+          Here&apos;s what happens when an AI agent uses a GraphQL API to answer
+          a real business question — from initial request to typed response.
         </p>
 
         <style dangerouslySetInnerHTML={{ __html: SYNTAX_CSS }} />
@@ -151,7 +157,7 @@ export function HowItWorks() {
               {i < steps.length - 1 && (
                 <>
                   {/* Horizontal arrow for lg+ */}
-                  <div className="absolute right-0 top-10 z-10 hidden lg:flex size-6 items-center justify-center rounded-full border-2 border-neu-100 bg-neu-0 dark:border-neu-50">
+                  <div className="absolute right-0 top-10 z-10 hidden size-6 items-center justify-center rounded-full border-2 border-neu-100 bg-neu-0 dark:border-neu-50 lg:flex">
                     <svg
                       width="10"
                       height="10"

--- a/src/app/(main)/ai/components/interactive-demo.tsx
+++ b/src/app/(main)/ai/components/interactive-demo.tsx
@@ -4,9 +4,7 @@ import { useState, useRef, useEffect, useCallback } from "react"
 import { graphql } from "graphql"
 import { StarWarsSchema } from "@/components/interactive-code-block/swapi-schema"
 import { SectionLabel } from "@/app/conf/_design-system/section-label"
-import { Button } from "@/app/conf/_design-system/button"
 import SparklesIcon from "@/app/conf/_design-system/pixelarticons/zap.svg?svgr"
-import PlayIcon from "@/app/conf/_design-system/pixelarticons/play.svg?svgr"
 import CheckIcon from "@/app/conf/_design-system/pixelarticons/check.svg?svgr"
 import SearchIcon from "@/app/conf/_design-system/pixelarticons/search.svg?svgr"
 import CodeIcon from "@/app/conf/_design-system/pixelarticons/code.svg?svgr"
@@ -169,7 +167,6 @@ type Step =
 
 export function InteractiveDemo() {
   const [step, setStep] = useState<Step>({ kind: "idle" })
-  const [customPrompt, setCustomPrompt] = useState("")
   const [isRunning, setIsRunning] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null!)
   const mountedRef = useRef(true)
@@ -232,35 +229,6 @@ export function InteractiveDemo() {
     },
     [isRunning],
   )
-
-  function runCustom() {
-    if (isRunning || !customPrompt.trim()) return
-    const lower = customPrompt.toLowerCase()
-    let matched: DemoPrompt
-    if (lower.includes("friend") || lower.includes("luke"))
-      matched = demoPrompts[1]
-    else if (
-      lower.includes("movie") ||
-      lower.includes("r2") ||
-      lower.includes("c3po") ||
-      lower.includes("appear")
-    )
-      matched = demoPrompts[2]
-    else if (lower.includes("tallest") || lower.includes("height"))
-      matched = demoPrompts[3]
-    else if (
-      lower.includes("starship") ||
-      lower.includes("spaceship") ||
-      lower.includes("length") ||
-      lower.includes("feet") ||
-      lower.includes("meter")
-    )
-      matched = demoPrompts[4]
-    else if (lower.includes("hero") || lower.includes("episode"))
-      matched = demoPrompts[5]
-    else matched = demoPrompts[0]
-    runDemo(matched)
-  }
 
   return (
     <section
@@ -326,31 +294,6 @@ export function InteractiveDemo() {
                 )
               })}
             </div>
-
-            {/* Custom prompt */}
-            <div className="mt-4 flex gap-2">
-              <input
-                type="text"
-                value={customPrompt}
-                onChange={e => setCustomPrompt(e.target.value)}
-                onKeyDown={e => {
-                  if (e.key === "Enter") runCustom()
-                }}
-                placeholder="Or type your own prompt…"
-                disabled={isRunning}
-                className="typography-body-sm flex-1 rounded-lg border border-neu-200 bg-neu-0 px-4 py-3 text-neu-900 placeholder:text-neu-400 focus:border-pri-base focus:outline-none focus:ring-2 focus:ring-pri-base/15 disabled:cursor-not-allowed dark:border-neu-100 dark:bg-neu-0 dark:placeholder:text-neu-500"
-              />
-              <Button
-                variant="primary"
-                size="md"
-                disabled={isRunning || !customPrompt.trim()}
-                onClick={runCustom}
-                isIconButton
-                aria-label="Run custom prompt"
-              >
-                <PlayIcon className="size-5" />
-              </Button>
-            </div>
           </div>
 
           {/* ── Right: Visualization ── */}
@@ -407,7 +350,7 @@ function IdleState() {
           <SparklesIcon className="size-8 text-pri-base/60" />
         </div>
         <p className="typography-body-md mt-5 text-neu-600">
-          Select an example prompt or type your own
+          Select an example prompt to begin
         </p>
         <p className="typography-body-sm mt-2 text-neu-400">
           Watch the AI → GraphQL translation step by step

--- a/src/app/(main)/ai/components/interactive-demo.tsx
+++ b/src/app/(main)/ai/components/interactive-demo.tsx
@@ -1,0 +1,660 @@
+"use client"
+
+import { useState, useRef, useEffect, useCallback } from "react"
+import { graphql } from "graphql"
+import { StarWarsSchema } from "@/components/interactive-code-block/swapi-schema"
+import { SectionLabel } from "@/app/conf/_design-system/section-label"
+import { Button } from "@/app/conf/_design-system/button"
+import SparklesIcon from "@/app/conf/_design-system/pixelarticons/zap.svg?svgr"
+import PlayIcon from "@/app/conf/_design-system/pixelarticons/play.svg?svgr"
+import CheckIcon from "@/app/conf/_design-system/pixelarticons/check.svg?svgr"
+import SearchIcon from "@/app/conf/_design-system/pixelarticons/search.svg?svgr"
+import CodeIcon from "@/app/conf/_design-system/pixelarticons/code.svg?svgr"
+import CloseIcon from "@/app/conf/_design-system/pixelarticons/close.svg?svgr"
+import { highlightGraphQL, highlightJSON, SYNTAX_CSS } from "./syntax-highlight"
+
+/* ─────────────────────────────────────────────
+   Demo data
+   ───────────────────────────────────────────── */
+
+type DemoPrompt = {
+  id: string
+  prompt: string
+  icon: string
+  query: string
+  explanation: string
+  discoveredTypes: string[]
+}
+
+const demoPrompts: DemoPrompt[] = [
+  {
+    id: "all-characters",
+    prompt: "Find all Star Wars characters",
+    icon: "👥",
+    query: `{
+  allHumans: __type(name: "Human") {
+    name
+  }
+  search(text: "") {
+    ... on Human {
+      name
+      height
+      appearsIn
+    }
+    ... on Droid {
+      name
+      primaryFunction
+    }
+    ... on Starship {
+      name
+      length
+    }
+  }
+}`,
+    explanation:
+      "The AI used introspection to discover the Human, Droid, and Starship types, then composed a single query with inline fragments to fetch across all types — one request instead of three.",
+    discoveredTypes: ["Human", "Droid", "Starship"],
+  },
+  {
+    id: "luke-friends",
+    prompt: "Show me Luke's friends and their starships",
+    icon: "🚀",
+    query: `{
+  human(id: "1000") {
+    name
+    friends {
+      name
+      ... on Human {
+        starships {
+          name
+        }
+      }
+    }
+  }
+}`,
+    explanation:
+      "The AI followed the schema relationships: human → friends → Character. It used an inline fragment to conditionally fetch starships only when the friend is a Human, showing how GraphQL handles polymorphic types naturally.",
+    discoveredTypes: ["Human", "Character", "Starship"],
+  },
+  {
+    id: "r2-c3po",
+    prompt: "What movies did R2-D2 and C-3PO appear in?",
+    icon: "🤖",
+    query: `{
+  r2d2: droid(id: "2001") {
+    name
+    appearsIn
+  }
+  c3po: droid(id: "2000") {
+    name
+    appearsIn
+  }
+}`,
+    explanation:
+      "Using GraphQL aliases, the AI fetched both droids in a single request — no over-fetching, no multiple API calls. Each alias produces a separately keyed result for easy processing.",
+    discoveredTypes: ["Droid", "Episode"],
+  },
+  {
+    id: "tallest",
+    prompt: "Find the tallest Star Wars character",
+    icon: "📏",
+    query: `{
+  search(text: "") {
+    ... on Human {
+      name
+      height
+    }
+  }
+}`,
+    explanation:
+      "The AI requested only the fields it needs (name, height) from the Human type. This minimized payload — no unnecessary starship or planet data was transferred, unlike a typical REST endpoint.",
+    discoveredTypes: ["Human"],
+  },
+  {
+    id: "starships-feet",
+    prompt: "Compare starship lengths in meters and feet",
+    icon: "📐",
+    query: `{
+  search(text: "") {
+    ... on Starship {
+      name
+      lengthInMeters: length
+      lengthInFeet: length(unit: FOOT)
+    }
+  }
+}`,
+    explanation:
+      "The AI discovered the `length` field, then used field arguments and aliases to compute both units in one query. No client-side conversion needed — the schema handles it server-side via GraphQL arguments.",
+    discoveredTypes: ["Starship"],
+  },
+  {
+    id: "heroes",
+    prompt: "Show me the hero of each episode and their friends",
+    icon: "⚔️",
+    query: `{
+  newHope: hero(episode: NEWHOPE) {
+    name
+    friends { name }
+  }
+  empire: hero(episode: EMPIRE) {
+    name
+    friends { name }
+  }
+  jedi: hero(episode: JEDI) {
+    name
+    friends { name }
+  }
+}`,
+    explanation:
+      "The AI composed three parallel queries using aliases and the `episode` argument. All three datasets return in a single network round-trip — REST would typically need 3+ sequential calls.",
+    discoveredTypes: ["Character", "Episode"],
+  },
+]
+
+/* ─────────────────────────────────────────────
+   Step state machine
+   ───────────────────────────────────────────── */
+
+type Step =
+  | { kind: "idle" }
+  | { kind: "introspecting"; prompt: DemoPrompt }
+  | { kind: "types-discovered"; prompt: DemoPrompt }
+  | { kind: "composing"; prompt: DemoPrompt; chars: number }
+  | { kind: "executing"; prompt: DemoPrompt; query: string }
+  | { kind: "result"; prompt: DemoPrompt; query: string; result: string }
+
+/* ─────────────────────────────────────────────
+   Component
+   ───────────────────────────────────────────── */
+
+export function InteractiveDemo() {
+  const [step, setStep] = useState<Step>({ kind: "idle" })
+  const [customPrompt, setCustomPrompt] = useState("")
+  const [isRunning, setIsRunning] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null!)
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const activePrompt =
+    step.kind !== "idle" ? step.prompt : null
+
+  const runDemo = useCallback(async (prompt: DemoPrompt) => {
+    if (isRunning) return
+    const update = (next: Step) => {
+      if (mountedRef.current) setStep(next)
+    }
+    setIsRunning(true)
+
+    // Step 1: Introspection (show types being discovered)
+    update({ kind: "introspecting", prompt })
+    await delay(600)
+    update({ kind: "types-discovered", prompt })
+    await delay(1000)
+
+    // Step 2: Composing (type out the query with a cursor)
+    update({ kind: "composing", prompt, chars: 0 })
+    for (let i = 1; i <= prompt.query.length; i++) {
+      await delay(Math.random() * 12 + 5)
+      update({ kind: "composing", prompt, chars: i })
+    }
+    await delay(250)
+
+    // Step 3: Executing
+    update({ kind: "executing", prompt, query: prompt.query })
+    await delay(400)
+
+    // Step 4: Result
+    try {
+      const execResult = await graphql({
+        schema: StarWarsSchema,
+        source: prompt.query,
+      })
+      update({
+        kind: "result",
+        prompt,
+        query: prompt.query,
+        result: JSON.stringify(execResult, null, 2),
+      })
+    } catch (error) {
+      update({
+        kind: "result",
+        prompt,
+        query: prompt.query,
+        result: JSON.stringify({ error: String(error) }, null, 2),
+      })
+    }
+    if (mountedRef.current) setIsRunning(false)
+
+  }, [isRunning])
+
+  function runCustom() {
+    if (isRunning || !customPrompt.trim()) return
+    const lower = customPrompt.toLowerCase()
+    let matched: DemoPrompt
+    if (lower.includes("friend") || lower.includes("luke")) matched = demoPrompts[1]
+    else if (lower.includes("movie") || lower.includes("r2") || lower.includes("c3po") || lower.includes("appear")) matched = demoPrompts[2]
+    else if (lower.includes("tallest") || lower.includes("height")) matched = demoPrompts[3]
+    else if (lower.includes("starship") || lower.includes("spaceship") || lower.includes("length") || lower.includes("feet") || lower.includes("meter")) matched = demoPrompts[4]
+    else if (lower.includes("hero") || lower.includes("episode")) matched = demoPrompts[5]
+    else matched = demoPrompts[0]
+    runDemo(matched)
+  }
+
+  return (
+    <section
+      id="interactive-demo"
+      className="overflow-hidden bg-neu-50 dark:bg-neu-50/25"
+    >
+      <div className="gql-container gql-section lg:py-16 xl:py-24">
+        <style dangerouslySetInnerHTML={{ __html: SYNTAX_CSS }} />
+        <SectionLabel className="mb-6">Interactive Demo</SectionLabel>
+        <h2 className="typography-h2 mb-2 lg:mb-4">
+          See GraphQL + AI in action
+        </h2>
+        <p className="typography-body-lg mb-8 max-w-2xl text-pretty text-neu-800 lg:mb-12">
+          Pick a prompt below and watch an AI agent introspect the schema, compose
+          a precise GraphQL query, and fetch structured results — all in real time.
+        </p>
+
+        <div ref={containerRef} className="gap-8 lg:flex">
+          {/* ── Left: Prompt picker ── */}
+          <div className="lg:w-[380px] lg:shrink-0 xl:w-[440px]">
+            <div className="flex flex-col gap-2">
+              {demoPrompts.map(p => {
+                const isActive = activePrompt?.id === p.id
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    disabled={isRunning}
+                    onClick={() => runDemo(p)}
+                    className={`gql-focus-visible group flex items-start gap-3 rounded-lg border p-3.5 text-left transition-all duration-200 disabled:cursor-not-allowed ${
+                      isActive
+                        ? "border-pri-base bg-pri-lightest/40 shadow-sm dark:bg-pri-darker/30"
+                        : "border-neu-200 bg-neu-0 hover:border-pri-base/40 hover:bg-pri-lightest/20 dark:border-neu-100 dark:hover:bg-pri-darker/15"
+                    }`}
+                  >
+                    <span className="mt-0.5 shrink-0 text-base leading-none">
+                      {p.icon}
+                    </span>
+                    <div className="min-w-0">
+                      <p className={`typography-body-sm font-medium truncate ${
+                        isActive ? "text-pri-dark" : "text-neu-900"
+                      }`}>
+                        {p.prompt}
+                      </p>
+                      <p className="typography-body-xs mt-0.5 text-neu-500">
+                        {p.discoveredTypes.length} type{p.discoveredTypes.length > 1 ? "s" : ""} discovered
+                        {isActive && " · running…"}
+                      </p>
+                    </div>
+                    {isActive && (
+                      <span className="ml-auto mt-0.5 shrink-0">
+                        <span className="relative flex size-2">
+                          <span className="absolute inline-flex size-2 animate-ping rounded-full bg-pri-base opacity-75" />
+                          <span className="relative inline-flex size-2 rounded-full bg-pri-base" />
+                        </span>
+                      </span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+
+            {/* Custom prompt */}
+            <div className="mt-4 flex gap-2">
+              <input
+                type="text"
+                value={customPrompt}
+                onChange={e => setCustomPrompt(e.target.value)}
+                onKeyDown={e => { if (e.key === "Enter") runCustom() }}
+                placeholder="Or type your own prompt…"
+                disabled={isRunning}
+                className="typography-body-sm flex-1 rounded-lg border border-neu-200 bg-neu-0 px-4 py-3 text-neu-900 placeholder:text-neu-400 focus:border-pri-base focus:outline-none focus:ring-2 focus:ring-pri-base/15 disabled:cursor-not-allowed dark:border-neu-100 dark:bg-neu-0 dark:placeholder:text-neu-500"
+              />
+              <Button
+                variant="primary"
+                size="md"
+                disabled={isRunning || !customPrompt.trim()}
+                onClick={runCustom}
+                isIconButton
+                aria-label="Run custom prompt"
+              >
+                <PlayIcon className="size-5" />
+              </Button>
+            </div>
+          </div>
+
+          {/* ── Right: Visualization ── */}
+          <div className="mt-8 flex-1 lg:mt-0">
+            <DemoVisualization step={step} containerRef={containerRef} />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* ─────────────────────────────────────────────
+   Visualization panel
+   ───────────────────────────────────────────── */
+
+function DemoVisualization({
+  step,
+  containerRef,
+}: {
+  step: Step
+  containerRef: React.RefObject<HTMLDivElement>
+}) {
+  switch (step.kind) {
+    case "idle":
+      return <IdleState />
+    case "introspecting":
+      return <Introspecting prompt={step.prompt} />
+    case "types-discovered":
+      return <TypesDiscovered prompt={step.prompt} />
+    case "composing":
+      return <Composing prompt={step.prompt} chars={step.chars} />
+    case "executing":
+      return <Executing prompt={step.prompt} query={step.query} />
+    case "result":
+      return (
+        <ResultView
+          prompt={step.prompt}
+          query={step.query}
+          result={step.result}
+          containerRef={containerRef}
+        />
+      )
+  }
+}
+
+/* ── Idle ── */
+
+function IdleState() {
+  return (
+    <div className="flex min-h-[440px] items-center justify-center rounded-xl border-2 border-dashed border-neu-300 bg-neu-0 p-8 dark:border-neu-100">
+      <div className="text-center">
+        <div className="mx-auto flex size-16 items-center justify-center rounded-2xl bg-pri-lightest/40 dark:bg-pri-darker/20">
+          <SparklesIcon className="size-8 text-pri-base/60" />
+        </div>
+        <p className="typography-body-md mt-5 text-neu-600">
+          Select an example prompt or type your own
+        </p>
+        <p className="typography-body-sm mt-2 text-neu-400">
+          Watch the AI → GraphQL translation step by step
+        </p>
+      </div>
+    </div>
+  )
+}
+
+/* ── Introspecting ── */
+
+function Introspecting({ prompt }: { prompt: DemoPrompt }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-neu-200 bg-neu-0 shadow-sm dark:border-neu-100">
+      <PanelHeader icon={<SearchIcon className="size-4 text-pri-base" />} label="Introspection">
+        <span className="typography-body-xs flex items-center gap-1.5 text-pri-base">
+          <span className="flex size-1.5 rounded-full bg-pri-base animate-pulse" />
+          Querying __schema…
+        </span>
+      </PanelHeader>
+      <div className="bg-[#1e1e2e] p-5">
+        <pre className="font-mono text-sm leading-relaxed">
+          <code className="text-[#6c7086]">{`# AI sends introspection query
+{
+  __schema {
+    queryType { name }
+    types {
+      name
+      kind
+      fields { name type { name kind } }
+    }
+  }
+}`}</code>
+        </pre>
+        <div className="mt-4 flex items-center gap-2">
+          <div className="h-px flex-1 bg-neu-100/10" />
+          <span className="typography-body-xs flex items-center gap-2 text-[#6c7086]">
+            <span className="flex gap-1">
+              {[0, 1, 2].map(i => (
+                <span
+                  key={i}
+                  className="inline-block size-1.5 animate-bounce rounded-full bg-pri-base"
+                  style={{ animationDelay: `${i * 120}ms` }}
+                />
+              ))}
+            </span>
+            Discovering schema for: <span className="text-[#f9e2af]">{prompt.prompt}</span>
+          </span>
+          <div className="h-px flex-1 bg-neu-100/10" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── Types Disclosed ── */
+
+function TypesDiscovered({ prompt }: { prompt: DemoPrompt }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-pri-base/30 bg-neu-0 shadow-sm shadow-pri-base/5 dark:border-pri-base/40">
+      <PanelHeader icon={<SearchIcon className="size-4 text-pri-base" />} label="Introspection" highlight>
+        <span className="typography-body-xs flex items-center gap-1.5 text-sec-dark">
+          <CheckIcon className="size-3" />
+          Found {prompt.discoveredTypes.length} relevant type{prompt.discoveredTypes.length > 1 ? "s" : ""}
+        </span>
+      </PanelHeader>
+      <div className="bg-[#1e1e2e] p-5">
+        <p className="font-mono text-xs text-[#6c7086] mb-3">
+          <span className="text-[#cba6f7]">__schema</span> → types discovered:
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {prompt.discoveredTypes.map((type, i) => (
+            <span
+              key={type}
+              className="inline-flex items-center gap-1.5 rounded-md border border-[#f9e2af]/30 bg-[#f9e2af]/10 px-2.5 py-1.5 font-mono text-sm text-[#f9e2af]"
+              style={{
+                animationDelay: `${i * 200}ms`,
+                animation: "fadeInUp 0.4s ease-out both",
+              }}
+            >
+              <span className="text-[#6c7086] text-xs">
+                "type"
+              </span>
+              {type}
+            </span>
+          ))}
+        </div>
+        <p className="typography-body-xs mt-4 text-[#a6e3a1]">
+          ✓ Self-describing schema — no hand-written tool definitions required
+        </p>
+      </div>
+    </div>
+  )
+}
+
+/* ── Composing ── */
+
+function Composing({ prompt, chars }: { prompt: DemoPrompt; chars: number }) {
+  const visible = prompt.query.slice(0, chars)
+  const cursor = chars < prompt.query.length
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-pri-base/20 bg-neu-0 shadow-sm dark:border-pri-base/30">
+      <PanelHeader icon={<CodeIcon className="size-4 text-pri-base" />} label="AI-generated GraphQL query" highlight>
+        <span className="typography-body-xs flex items-center gap-1.5 text-pri-base">
+          <span className="flex size-1.5 rounded-full bg-pri-base animate-pulse" />
+          Composing…
+        </span>
+      </PanelHeader>
+      <div className="bg-[#1e1e2e] p-5">
+        <pre className="font-mono text-sm leading-relaxed">
+          <code
+            dangerouslySetInnerHTML={{
+              __html: highlightGraphQL(visible) +
+                (cursor
+                  ? '<span class="inline-block w-2 h-[1.1em] bg-[#f5c2e7] ml-0.5 align-text-bottom animate-pulse" />'
+                  : ""),
+            }}
+          />
+        </pre>
+        <div className="mt-3 flex items-center gap-2 text-xs text-[#6c7086]">
+          <span>{chars} / {prompt.query.length} chars</span>
+          <div className="h-1 flex-1 overflow-hidden rounded-full bg-neu-100/10">
+            <div
+              className="h-full rounded-full bg-pri-base/60 transition-all duration-100"
+              style={{ width: `${((chars / prompt.query.length) * 100).toFixed(1)}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── Executing ── */
+
+function Executing({ prompt, query }: { prompt: DemoPrompt; query: string }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-pri-base/20 bg-neu-0 shadow-sm dark:border-pri-base/30">
+      <PanelHeader icon={<CodeIcon className="size-4 text-pri-base" />} label="AI-generated GraphQL query" highlight>
+        <span className="typography-body-xs flex items-center gap-1.5 text-sec-dark">
+          <CheckIcon className="size-3" />
+          Query complete
+        </span>
+      </PanelHeader>
+      <div className="bg-[#1e1e2e] p-5">
+        <pre className="font-mono text-sm leading-relaxed">
+          <code dangerouslySetInnerHTML={{ __html: highlightGraphQL(query) }} />
+        </pre>
+        <div className="mt-4 flex items-center gap-3">
+          <span className="flex gap-1">
+            {[0, 1, 2].map(i => (
+              <span
+                key={i}
+                className="inline-block size-1.5 animate-bounce rounded-full bg-[#a6e3a1]"
+                style={{ animationDelay: `${i * 100}ms` }}
+              />
+            ))}
+          </span>
+          <span className="font-mono text-xs text-[#a6e3a1]">
+            Executing against GraphQL endpoint…
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── Result ── */
+
+function ResultView({
+  prompt,
+  query,
+  result,
+  containerRef,
+}: {
+  prompt: DemoPrompt
+  query: string
+  result: string
+  containerRef: React.RefObject<HTMLDivElement>
+}) {
+  return (
+    <div className="space-y-4">
+      {/* Query */}
+      <div className="overflow-hidden rounded-xl border border-neu-200 bg-neu-0 shadow-sm dark:border-neu-100">
+        <PanelHeader icon={<SparklesIcon className="size-4 text-pri-base" />} label="AI-generated GraphQL query">
+          <span className="typography-body-xs flex items-center gap-1.5 text-sec-dark">
+            <CheckIcon className="size-3" />
+            Executed
+          </span>
+        </PanelHeader>
+        <div className="bg-[#1e1e2e] p-5">
+          <pre className="font-mono text-sm leading-relaxed">
+            <code
+              dangerouslySetInnerHTML={{ __html: highlightGraphQL(query) }}
+            />
+          </pre>
+        </div>
+      </div>
+
+      {/* Explanation */}
+      <div className="rounded-xl border border-sec-dark/20 bg-sec-light/15 p-4 dark:border-sec-base/15 dark:bg-sec-darker/15">
+        <div className="flex items-start gap-2">
+          <span className="mt-0.5 shrink-0 text-sm">{prompt.icon}</span>
+          <div>
+            <p className="typography-body-sm font-medium text-neu-900">
+              What just happened
+            </p>
+            <p className="typography-body-sm mt-1 text-neu-700">
+              {prompt.explanation}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* JSON Result */}
+      <div className="overflow-hidden rounded-xl border border-neu-200 bg-neu-0 shadow-sm dark:border-neu-100">
+        <PanelHeader icon={<CheckIcon className="size-4 text-sec-dark" />} label="Structured response (JSON)">
+          <span className="typography-body-xs text-neu-500">
+            {result.length.toLocaleString()} bytes
+          </span>
+        </PanelHeader>
+        <div ref={containerRef} className="max-h-[400px] overflow-auto bg-[#1e1e2e] p-5">
+          <pre className="font-mono text-sm leading-relaxed">
+            <code
+              dangerouslySetInnerHTML={{ __html: highlightJSON(result) }}
+            />
+          </pre>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ─────────────────────────────────────────────
+   Shared sub-components
+   ───────────────────────────────────────────── */
+
+function PanelHeader({
+  icon,
+  label,
+  highlight,
+  children,
+}: {
+  icon: React.ReactNode
+  label: string
+  highlight?: boolean
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      className={`flex items-center gap-2 border-b px-4 py-2.5 ${
+        highlight
+          ? "border-pri-base/20 bg-pri-lightest/40 dark:border-pri-base/30 dark:bg-pri-darker/20"
+          : "border-neu-200 bg-neu-50 dark:border-neu-100 dark:bg-neu-50/25"
+      }`}
+    >
+      {icon}
+      <span className="typography-body-sm font-mono font-medium text-neu-700 flex-1">
+        {label}
+      </span>
+      {children}
+    </div>
+  )
+}
+
+/* ─────────────────────────────────────────────
+   Helpers
+   ───────────────────────────────────────────── */
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/src/app/(main)/ai/components/interactive-demo.tsx
+++ b/src/app/(main)/ai/components/interactive-demo.tsx
@@ -180,67 +180,84 @@ export function InteractiveDemo() {
     }
   }, [])
 
-  const activePrompt =
-    step.kind !== "idle" ? step.prompt : null
+  const activePrompt = step.kind !== "idle" ? step.prompt : null
 
-  const runDemo = useCallback(async (prompt: DemoPrompt) => {
-    if (isRunning) return
-    const update = (next: Step) => {
-      if (mountedRef.current) setStep(next)
-    }
-    setIsRunning(true)
+  const runDemo = useCallback(
+    async (prompt: DemoPrompt) => {
+      if (isRunning) return
+      const update = (next: Step) => {
+        if (mountedRef.current) setStep(next)
+      }
+      setIsRunning(true)
 
-    // Step 1: Introspection (show types being discovered)
-    update({ kind: "introspecting", prompt })
-    await delay(600)
-    update({ kind: "types-discovered", prompt })
-    await delay(1000)
+      // Step 1: Introspection (show types being discovered)
+      update({ kind: "introspecting", prompt })
+      await delay(600)
+      update({ kind: "types-discovered", prompt })
+      await delay(1000)
 
-    // Step 2: Composing (type out the query with a cursor)
-    update({ kind: "composing", prompt, chars: 0 })
-    for (let i = 1; i <= prompt.query.length; i++) {
-      await delay(Math.random() * 12 + 5)
-      update({ kind: "composing", prompt, chars: i })
-    }
-    await delay(250)
+      // Step 2: Composing (type out the query with a cursor)
+      update({ kind: "composing", prompt, chars: 0 })
+      for (let i = 1; i <= prompt.query.length; i++) {
+        await delay(Math.random() * 12 + 5)
+        update({ kind: "composing", prompt, chars: i })
+      }
+      await delay(250)
 
-    // Step 3: Executing
-    update({ kind: "executing", prompt, query: prompt.query })
-    await delay(400)
+      // Step 3: Executing
+      update({ kind: "executing", prompt, query: prompt.query })
+      await delay(400)
 
-    // Step 4: Result
-    try {
-      const execResult = await graphql({
-        schema: StarWarsSchema,
-        source: prompt.query,
-      })
-      update({
-        kind: "result",
-        prompt,
-        query: prompt.query,
-        result: JSON.stringify(execResult, null, 2),
-      })
-    } catch (error) {
-      update({
-        kind: "result",
-        prompt,
-        query: prompt.query,
-        result: JSON.stringify({ error: String(error) }, null, 2),
-      })
-    }
-    if (mountedRef.current) setIsRunning(false)
-
-  }, [isRunning])
+      // Step 4: Result
+      try {
+        const execResult = await graphql({
+          schema: StarWarsSchema,
+          source: prompt.query,
+        })
+        update({
+          kind: "result",
+          prompt,
+          query: prompt.query,
+          result: JSON.stringify(execResult, null, 2),
+        })
+      } catch (error) {
+        update({
+          kind: "result",
+          prompt,
+          query: prompt.query,
+          result: JSON.stringify({ error: String(error) }, null, 2),
+        })
+      }
+      if (mountedRef.current) setIsRunning(false)
+    },
+    [isRunning],
+  )
 
   function runCustom() {
     if (isRunning || !customPrompt.trim()) return
     const lower = customPrompt.toLowerCase()
     let matched: DemoPrompt
-    if (lower.includes("friend") || lower.includes("luke")) matched = demoPrompts[1]
-    else if (lower.includes("movie") || lower.includes("r2") || lower.includes("c3po") || lower.includes("appear")) matched = demoPrompts[2]
-    else if (lower.includes("tallest") || lower.includes("height")) matched = demoPrompts[3]
-    else if (lower.includes("starship") || lower.includes("spaceship") || lower.includes("length") || lower.includes("feet") || lower.includes("meter")) matched = demoPrompts[4]
-    else if (lower.includes("hero") || lower.includes("episode")) matched = demoPrompts[5]
+    if (lower.includes("friend") || lower.includes("luke"))
+      matched = demoPrompts[1]
+    else if (
+      lower.includes("movie") ||
+      lower.includes("r2") ||
+      lower.includes("c3po") ||
+      lower.includes("appear")
+    )
+      matched = demoPrompts[2]
+    else if (lower.includes("tallest") || lower.includes("height"))
+      matched = demoPrompts[3]
+    else if (
+      lower.includes("starship") ||
+      lower.includes("spaceship") ||
+      lower.includes("length") ||
+      lower.includes("feet") ||
+      lower.includes("meter")
+    )
+      matched = demoPrompts[4]
+    else if (lower.includes("hero") || lower.includes("episode"))
+      matched = demoPrompts[5]
     else matched = demoPrompts[0]
     runDemo(matched)
   }
@@ -257,8 +274,9 @@ export function InteractiveDemo() {
           See GraphQL + AI in action
         </h2>
         <p className="typography-body-lg mb-8 max-w-2xl text-pretty text-neu-800 lg:mb-12">
-          Pick a prompt below and watch an AI agent introspect the schema, compose
-          a precise GraphQL query, and fetch structured results — all in real time.
+          Pick a prompt below and watch an AI agent introspect the schema,
+          compose a precise GraphQL query, and fetch structured results — all in
+          real time.
         </p>
 
         <div ref={containerRef} className="gap-8 lg:flex">
@@ -283,13 +301,16 @@ export function InteractiveDemo() {
                       {p.icon}
                     </span>
                     <div className="min-w-0">
-                      <p className={`typography-body-sm font-medium truncate ${
-                        isActive ? "text-pri-dark" : "text-neu-900"
-                      }`}>
+                      <p
+                        className={`typography-body-sm truncate font-medium ${
+                          isActive ? "text-pri-dark" : "text-neu-900"
+                        }`}
+                      >
                         {p.prompt}
                       </p>
                       <p className="typography-body-xs mt-0.5 text-neu-500">
-                        {p.discoveredTypes.length} type{p.discoveredTypes.length > 1 ? "s" : ""} discovered
+                        {p.discoveredTypes.length} type
+                        {p.discoveredTypes.length > 1 ? "s" : ""} discovered
                         {isActive && " · running…"}
                       </p>
                     </div>
@@ -312,7 +333,9 @@ export function InteractiveDemo() {
                 type="text"
                 value={customPrompt}
                 onChange={e => setCustomPrompt(e.target.value)}
-                onKeyDown={e => { if (e.key === "Enter") runCustom() }}
+                onKeyDown={e => {
+                  if (e.key === "Enter") runCustom()
+                }}
                 placeholder="Or type your own prompt…"
                 disabled={isRunning}
                 className="typography-body-sm flex-1 rounded-lg border border-neu-200 bg-neu-0 px-4 py-3 text-neu-900 placeholder:text-neu-400 focus:border-pri-base focus:outline-none focus:ring-2 focus:ring-pri-base/15 disabled:cursor-not-allowed dark:border-neu-100 dark:bg-neu-0 dark:placeholder:text-neu-500"
@@ -399,9 +422,12 @@ function IdleState() {
 function Introspecting({ prompt }: { prompt: DemoPrompt }) {
   return (
     <div className="overflow-hidden rounded-xl border border-neu-200 bg-neu-0 shadow-sm dark:border-neu-100">
-      <PanelHeader icon={<SearchIcon className="size-4 text-pri-base" />} label="Introspection">
+      <PanelHeader
+        icon={<SearchIcon className="size-4 text-pri-base" />}
+        label="Introspection"
+      >
         <span className="typography-body-xs flex items-center gap-1.5 text-pri-base">
-          <span className="flex size-1.5 rounded-full bg-pri-base animate-pulse" />
+          <span className="flex size-1.5 animate-pulse rounded-full bg-pri-base" />
           Querying __schema…
         </span>
       </PanelHeader>
@@ -431,7 +457,8 @@ function Introspecting({ prompt }: { prompt: DemoPrompt }) {
                 />
               ))}
             </span>
-            Discovering schema for: <span className="text-[#f9e2af]">{prompt.prompt}</span>
+            Discovering schema for:{" "}
+            <span className="text-[#f9e2af]">{prompt.prompt}</span>
           </span>
           <div className="h-px flex-1 bg-neu-100/10" />
         </div>
@@ -445,14 +472,19 @@ function Introspecting({ prompt }: { prompt: DemoPrompt }) {
 function TypesDiscovered({ prompt }: { prompt: DemoPrompt }) {
   return (
     <div className="overflow-hidden rounded-xl border border-pri-base/30 bg-neu-0 shadow-sm shadow-pri-base/5 dark:border-pri-base/40">
-      <PanelHeader icon={<SearchIcon className="size-4 text-pri-base" />} label="Introspection" highlight>
+      <PanelHeader
+        icon={<SearchIcon className="size-4 text-pri-base" />}
+        label="Introspection"
+        highlight
+      >
         <span className="typography-body-xs flex items-center gap-1.5 text-sec-dark">
           <CheckIcon className="size-3" />
-          Found {prompt.discoveredTypes.length} relevant type{prompt.discoveredTypes.length > 1 ? "s" : ""}
+          Found {prompt.discoveredTypes.length} relevant type
+          {prompt.discoveredTypes.length > 1 ? "s" : ""}
         </span>
       </PanelHeader>
       <div className="bg-[#1e1e2e] p-5">
-        <p className="font-mono text-xs text-[#6c7086] mb-3">
+        <p className="mb-3 font-mono text-xs text-[#6c7086]">
           <span className="text-[#cba6f7]">__schema</span> → types discovered:
         </p>
         <div className="flex flex-wrap gap-2">
@@ -465,9 +497,7 @@ function TypesDiscovered({ prompt }: { prompt: DemoPrompt }) {
                 animation: "fadeInUp 0.4s ease-out both",
               }}
             >
-              <span className="text-[#6c7086] text-xs">
-                "type"
-              </span>
+              <span className="text-xs text-[#6c7086]">"type"</span>
               {type}
             </span>
           ))}
@@ -488,9 +518,13 @@ function Composing({ prompt, chars }: { prompt: DemoPrompt; chars: number }) {
 
   return (
     <div className="overflow-hidden rounded-xl border border-pri-base/20 bg-neu-0 shadow-sm dark:border-pri-base/30">
-      <PanelHeader icon={<CodeIcon className="size-4 text-pri-base" />} label="AI-generated GraphQL query" highlight>
+      <PanelHeader
+        icon={<CodeIcon className="size-4 text-pri-base" />}
+        label="AI-generated GraphQL query"
+        highlight
+      >
         <span className="typography-body-xs flex items-center gap-1.5 text-pri-base">
-          <span className="flex size-1.5 rounded-full bg-pri-base animate-pulse" />
+          <span className="flex size-1.5 animate-pulse rounded-full bg-pri-base" />
           Composing…
         </span>
       </PanelHeader>
@@ -498,7 +532,8 @@ function Composing({ prompt, chars }: { prompt: DemoPrompt; chars: number }) {
         <pre className="font-mono text-sm leading-relaxed">
           <code
             dangerouslySetInnerHTML={{
-              __html: highlightGraphQL(visible) +
+              __html:
+                highlightGraphQL(visible) +
                 (cursor
                   ? '<span class="inline-block w-2 h-[1.1em] bg-[#f5c2e7] ml-0.5 align-text-bottom animate-pulse" />'
                   : ""),
@@ -506,11 +541,15 @@ function Composing({ prompt, chars }: { prompt: DemoPrompt; chars: number }) {
           />
         </pre>
         <div className="mt-3 flex items-center gap-2 text-xs text-[#6c7086]">
-          <span>{chars} / {prompt.query.length} chars</span>
+          <span>
+            {chars} / {prompt.query.length} chars
+          </span>
           <div className="h-1 flex-1 overflow-hidden rounded-full bg-neu-100/10">
             <div
               className="h-full rounded-full bg-pri-base/60 transition-all duration-100"
-              style={{ width: `${((chars / prompt.query.length) * 100).toFixed(1)}%` }}
+              style={{
+                width: `${((chars / prompt.query.length) * 100).toFixed(1)}%`,
+              }}
             />
           </div>
         </div>
@@ -524,7 +563,11 @@ function Composing({ prompt, chars }: { prompt: DemoPrompt; chars: number }) {
 function Executing({ prompt, query }: { prompt: DemoPrompt; query: string }) {
   return (
     <div className="overflow-hidden rounded-xl border border-pri-base/20 bg-neu-0 shadow-sm dark:border-pri-base/30">
-      <PanelHeader icon={<CodeIcon className="size-4 text-pri-base" />} label="AI-generated GraphQL query" highlight>
+      <PanelHeader
+        icon={<CodeIcon className="size-4 text-pri-base" />}
+        label="AI-generated GraphQL query"
+        highlight
+      >
         <span className="typography-body-xs flex items-center gap-1.5 text-sec-dark">
           <CheckIcon className="size-3" />
           Query complete
@@ -570,7 +613,10 @@ function ResultView({
     <div className="space-y-4">
       {/* Query */}
       <div className="overflow-hidden rounded-xl border border-neu-200 bg-neu-0 shadow-sm dark:border-neu-100">
-        <PanelHeader icon={<SparklesIcon className="size-4 text-pri-base" />} label="AI-generated GraphQL query">
+        <PanelHeader
+          icon={<SparklesIcon className="size-4 text-pri-base" />}
+          label="AI-generated GraphQL query"
+        >
           <span className="typography-body-xs flex items-center gap-1.5 text-sec-dark">
             <CheckIcon className="size-3" />
             Executed
@@ -602,16 +648,20 @@ function ResultView({
 
       {/* JSON Result */}
       <div className="overflow-hidden rounded-xl border border-neu-200 bg-neu-0 shadow-sm dark:border-neu-100">
-        <PanelHeader icon={<CheckIcon className="size-4 text-sec-dark" />} label="Structured response (JSON)">
+        <PanelHeader
+          icon={<CheckIcon className="size-4 text-sec-dark" />}
+          label="Structured response (JSON)"
+        >
           <span className="typography-body-xs text-neu-500">
             {result.length.toLocaleString()} bytes
           </span>
         </PanelHeader>
-        <div ref={containerRef} className="max-h-[400px] overflow-auto bg-[#1e1e2e] p-5">
+        <div
+          ref={containerRef}
+          className="max-h-[400px] overflow-auto bg-[#1e1e2e] p-5"
+        >
           <pre className="font-mono text-sm leading-relaxed">
-            <code
-              dangerouslySetInnerHTML={{ __html: highlightJSON(result) }}
-            />
+            <code dangerouslySetInnerHTML={{ __html: highlightJSON(result) }} />
           </pre>
         </div>
       </div>
@@ -643,7 +693,7 @@ function PanelHeader({
       }`}
     >
       {icon}
-      <span className="typography-body-sm font-mono font-medium text-neu-700 flex-1">
+      <span className="typography-body-sm flex-1 font-mono font-medium text-neu-700">
         {label}
       </span>
       {children}

--- a/src/app/(main)/ai/components/syntax-highlight.tsx
+++ b/src/app/(main)/ai/components/syntax-highlight.tsx
@@ -17,10 +17,7 @@
 /* ── Shared helpers ── */
 
 function escapeHTML(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 }
 
 /* ── GraphQL query / SDL highlighting ── */
@@ -39,16 +36,10 @@ export function highlightGraphQL(source: string): string {
   )
 
   // Block strings (triple-quoted)
-  html = html.replace(
-    /("""[\s\S]*?""")/g,
-    '<span class="sh-string">$1</span>',
-  )
+  html = html.replace(/("""[\s\S]*?""")/g, '<span class="sh-string">$1</span>')
 
   // Comments
-  html = html.replace(
-    /(#[^\n]*)/g,
-    '<span class="sh-comment">$1</span>',
-  )
+  html = html.replace(/(#[^\n]*)/g, '<span class="sh-comment">$1</span>')
 
   // Directives (@skip, @include, @deprecated)
   html = html.replace(
@@ -82,7 +73,7 @@ export function highlightGraphQL(source: string): string {
       const before = html.substring(Math.max(0, offset - 60), offset)
       const alreadyWrapped =
         before.lastIndexOf('<span class="sh-type">') >
-        before.lastIndexOf('</span>')
+        before.lastIndexOf("</span>")
       if (alreadyWrapped) return match
       return `<span class="sh-type">${typeName}</span>`
     },
@@ -101,7 +92,7 @@ export function highlightGraphQL(source: string): string {
     ) => {
       // Don't highlight if already inside a span
       if (
-        _full.includes('<span') ||
+        _full.includes("<span") ||
         /^(query|mutation|subscription|fragment|type|input|interface|union|enum|scalar|schema|extend|implements|directive)$/.test(
           name,
         )
@@ -122,7 +113,10 @@ export function highlightGraphQL(source: string): string {
       name: string,
       brace: string,
     ) => {
-      if (_full.includes('<span') || /^(query|mutation|subscription|fragment|on)$/.test(name)) {
+      if (
+        _full.includes("<span") ||
+        /^(query|mutation|subscription|fragment|on)$/.test(name)
+      ) {
         return _full
       }
       return `${nl}${indent}<span class="sh-field">${name}</span>${brace}`
@@ -132,13 +126,8 @@ export function highlightGraphQL(source: string): string {
   // Arguments: parens and colons
   html = html.replace(
     /([a-zA-Z_][a-zA-Z0-9_]*)(\s*:)(\s*)/g,
-    (
-      _full: string,
-      name: string,
-      colon: string,
-      space: string,
-    ) => {
-      if (_full.includes('<span')) return _full
+    (_full: string, name: string, colon: string, space: string) => {
+      if (_full.includes("<span")) return _full
       return `<span class="sh-arg">${name}</span>${colon}${space}`
     },
   )
@@ -158,10 +147,7 @@ export function highlightGraphQLSchema(source: string): string {
   )
 
   // Comments
-  html = html.replace(
-    /(#[^\n]*)/g,
-    '<span class="sh-comment">$1</span>',
-  )
+  html = html.replace(/(#[^\n]*)/g, '<span class="sh-comment">$1</span>')
 
   // Directives
   html = html.replace(
@@ -194,7 +180,7 @@ export function highlightGraphQLSchema(source: string): string {
       const before = html.substring(Math.max(0, offset - 60), offset)
       const alreadyWrapped =
         before.lastIndexOf('<span class="sh-type">') >
-        before.lastIndexOf('</span>')
+        before.lastIndexOf("</span>")
       if (alreadyWrapped) return match
       return `<span class="sh-type">${typeName}</span>`
     },
@@ -210,7 +196,7 @@ export function highlightGraphQLSchema(source: string): string {
       name: string,
       colon: string,
     ) => {
-      if (_full.includes('<span')) return _full
+      if (_full.includes("<span")) return _full
       return `${nl}${indent}<span class="sh-field">${name}</span>${colon}`
     },
   )
@@ -273,25 +259,22 @@ export function highlightJSON(source: string): string {
 export function highlightPrompt(source: string): string {
   const html = escapeHTML(source)
   // Highlight the > prompt marker
-  return html.replace(
-    /^(>[^\n]*)/gm,
-    '<span class="sh-comment">$1</span>',
-  )
+  return html.replace(/^(>[^\n]*)/gm, '<span class="sh-comment">$1</span>')
 }
 
 /* ── CSS utility classes for the highlight spans ──
    Include these once in any parent that uses highlighted code.  ── */
 
 export const syntaxColors = {
-  comment:  "#6c7086",
-  keyword:  "#cba6f7",
-  type:     "#f9e2af",
-  field:    "#89b4fa",
-  string:   "#a6e3a1",
-  number:   "#fab387",
-  directive:"#f38ba8",
+  comment: "#6c7086",
+  keyword: "#cba6f7",
+  type: "#f9e2af",
+  field: "#89b4fa",
+  string: "#a6e3a1",
+  number: "#fab387",
+  directive: "#f38ba8",
   operator: "#94e2d5",
-  arg:      "#89dceb",
+  arg: "#89dceb",
 } as const
 
 /**

--- a/src/app/(main)/ai/components/syntax-highlight.tsx
+++ b/src/app/(main)/ai/components/syntax-highlight.tsx
@@ -2,7 +2,7 @@
 
 /**
  * Zero-dependency syntax highlighting for GraphQL and JSON.
- * Uses Catppuccin Mocha palette — matches the [##1e1e2e] dark background.
+ * Uses Catppuccin Mocha palette — matches the [#1e1e2e] dark background.
  *
  * Colors:
  *   #cba6f7 – mauve  (keywords: query, mutation, fragment, on, true, false, null)
@@ -12,6 +12,13 @@
  *   #fab387 – peach  (numbers)
  *   #6c7086 – overlay0 (comments, punctuation)
  *   #f38ba8 – red    (directives)
+ *
+ * Implementation note: each highlighter runs a single tokenizer pass over the
+ * escaped source and builds the HTML output as it goes, rather than running a
+ * sequence of string replacements on an already-built HTML string. This prevents
+ * later passes from matching keywords/types inside span attributes — the bug
+ * that previously turned `<span class="sh-type">` into `<span class="sh-
+ * <span class="sh-keyword">type</span>">`, leaking `type">` into the output.
  */
 
 /* ── Shared helpers ── */
@@ -20,246 +27,153 @@ function escapeHTML(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 }
 
+const wrap = (cls: string, text: string): string =>
+  `<span class="sh-${cls}">${text}</span>`
+
 /* ── GraphQL query / SDL highlighting ── */
 
 export function highlightGraphQL(source: string): string {
-  let html = escapeHTML(source)
+  const esc = escapeHTML(source)
 
-  // Strings (single and double quoted)
-  html = html.replace(
-    /("(?:\\.|[^"\\])*")/g,
-    '<span class="sh-string">$1</span>',
-  )
-  html = html.replace(
-    /('(?:\\.|[^'\\])*')/g,
-    '<span class="sh-string">$1</span>',
-  )
+  // Master tokenizer, processed left-to-right. Alternative groups are tried in
+  // order, so the first match wins (e.g. a scalar `Int` is consumed as a type
+  // before the general capitalized-type alternative can grab it).
+  const re =
+    /("""[\s\S]*?""")|("(?:\\.|[^"\\])*")|('(?:\\.|[^'\\])*')|(#[^\n]*)|(@[a-zA-Z_][a-zA-Z0-9_]*)|\b(String|Int|Float|Boolean|ID)\b|\b(query|mutation|subscription|fragment|on|true|false|null|type|input|interface|union|enum|scalar|schema|extend|implements|directive|repeatable)\b|(\.\.\.\s*on\b)|\b([A-Z][a-zA-Z0-9_]+)\b/g
 
-  // Block strings (triple-quoted)
-  html = html.replace(/("""[\s\S]*?""")/g, '<span class="sh-string">$1</span>')
+  let out = ""
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(esc)) !== null) {
+    out += esc.slice(last, m.index)
+    const [
+      full,
+      blockStr,
+      str,
+      sq,
+      comment,
+      directive,
+      scalar,
+      keyword,
+      spreadOn,
+      capType,
+    ] = m
+    if (blockStr) out += wrap("string", blockStr)
+    else if (str) out += wrap("string", str)
+    else if (sq) out += wrap("string", sq)
+    else if (comment) out += wrap("comment", comment)
+    else if (directive) out += wrap("directive", directive)
+    else if (scalar) out += wrap("type", scalar)
+    else if (keyword) out += wrap("keyword", keyword)
+    else if (spreadOn) out += wrap("operator", spreadOn)
+    else if (capType) out += wrap("type", capType)
+    last = m.index + full.length
+  }
+  out += esc.slice(last)
 
-  // Comments
-  html = html.replace(/(#[^\n]*)/g, '<span class="sh-comment">$1</span>')
-
-  // Directives (@skip, @include, @deprecated)
-  html = html.replace(
-    /(@[a-zA-Z_][a-zA-Z0-9_]*)/g,
-    '<span class="sh-directive">$1</span>',
-  )
-
-  // Scalar types & built-ins (must come before general type names)
-  html = html.replace(
-    /\b(String|Int|Float|Boolean|ID)\b/g,
-    '<span class="sh-type">$1</span>',
-  )
-
-  // GraphQL keywords
-  html = html.replace(
-    /\b(query|mutation|subscription|fragment|on|true|false|null|type|input|interface|union|enum|scalar|schema|extend|implements|directive|repeatable)\b/g,
-    '<span class="sh-keyword">$1</span>',
-  )
-
-  // ... on Type (inline fragment)
-  html = html.replace(
-    /(\.\.\.\s+on\s+)([A-Z][a-zA-Z0-9_]*)/g,
-    '<span class="sh-operator">$1</span><span class="sh-type">$2</span>',
-  )
-
-  // Standalone type names (Capitalized words that follow whitespace + are standalone)
-  html = html.replace(
-    /\b([A-Z][a-zA-Z0-9_]+)\b/g,
-    (match, typeName, offset) => {
-      // Check if this is already wrapped in a span
-      const before = html.substring(Math.max(0, offset - 60), offset)
-      const alreadyWrapped =
-        before.lastIndexOf('<span class="sh-type">') >
-        before.lastIndexOf("</span>")
-      if (alreadyWrapped) return match
-      return `<span class="sh-type">${typeName}</span>`
-    },
-  )
-
-  // Field names at line start (unquoted identifiers followed by : or ()
-  html = html.replace(
-    /(^|\n)(\s*)([a-zA-Z_][a-zA-Z0-9_]*)(\s*)([:(])/gm,
+  // Field names: a lowercase identifier at the start of a line, or just after a
+  // `{` / `(`, followed by `:` or `(`. Skip identifiers already wrapped.
+  out = out.replace(
+    /(^|[\n{(])(\s*)([a-z_][a-zA-Z0-9_]*)(\s*)([:()])/gm,
     (
-      _full: string,
-      nl: string,
-      indent: string,
+      _full,
+      pre: string,
+      space: string,
       name: string,
       gap: string,
       paren: string,
-    ) => {
-      // Don't highlight if already inside a span
-      if (
-        _full.includes("<span") ||
-        /^(query|mutation|subscription|fragment|type|input|interface|union|enum|scalar|schema|extend|implements|directive)$/.test(
-          name,
-        )
-      ) {
-        return _full
-      }
-      return `${nl}${indent}<span class="sh-field">${name}</span>${gap}${paren}`
-    },
+    ) =>
+      _full.includes("sh-")
+        ? _full
+        : `${pre}${space}${wrap("field", name)}${gap}${paren}`,
   )
 
-  // Nested field names (indented identifiers followed by space + {)
-  html = html.replace(
-    /(^|\n)(\s+)([a-zA-Z_][a-zA-Z0-9_]*)(\s*\{)/gm,
-    (
-      _full: string,
-      nl: string,
-      indent: string,
-      name: string,
-      brace: string,
-    ) => {
-      if (
-        _full.includes("<span") ||
-        /^(query|mutation|subscription|fragment|on)$/.test(name)
-      ) {
-        return _full
-      }
-      return `${nl}${indent}<span class="sh-field">${name}</span>${brace}`
-    },
-  )
+  // Non-null `!` and list `[` `]` markers
+  out = out.replace(/(!)/g, wrap("operator", "$1"))
+  out = out.replace(/([[\]])/g, wrap("operator", "$1"))
 
-  // Arguments: parens and colons
-  html = html.replace(
-    /([a-zA-Z_][a-zA-Z0-9_]*)(\s*:)(\s*)/g,
-    (_full: string, name: string, colon: string, space: string) => {
-      if (_full.includes("<span")) return _full
-      return `<span class="sh-arg">${name}</span>${colon}${space}`
-    },
-  )
-
-  return html
+  return out
 }
 
-/* ── GraphQL SDL (schema definition language) highlighting ── */
+/* ── GraphQL Schema (SDL) highlighting ── */
 
 export function highlightGraphQLSchema(source: string): string {
-  let html = escapeHTML(source)
+  const esc = escapeHTML(source)
 
-  // Strings
-  html = html.replace(
-    /("(?:\\.|[^"\\])*")/g,
-    '<span class="sh-string">$1</span>',
+  const re =
+    /("""[\s\S]*?""")|("(?:\\.|[^"\\])*")|(#[^\n]*)|(@[a-zA-Z_][a-zA-Z0-9_]*)|\b(String|Int|Float|Boolean|ID)\b|\b(type|input|interface|union|enum|scalar|schema|extend|implements|directive|repeatable|query|mutation|subscription|fragment|on|true|false|null)\b|\b([A-Z][a-zA-Z0-9_]+)\b/g
+
+  let out = ""
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(esc)) !== null) {
+    out += esc.slice(last, m.index)
+    const [full, blockStr, str, comment, directive, scalar, keyword, capType] =
+      m
+    if (blockStr) out += wrap("string", blockStr)
+    else if (str) out += wrap("string", str)
+    else if (comment) out += wrap("comment", comment)
+    else if (directive) out += wrap("directive", directive)
+    else if (scalar) out += wrap("type", scalar)
+    else if (keyword) out += wrap("keyword", keyword)
+    else if (capType) out += wrap("type", capType)
+    last = m.index + full.length
+  }
+  out += esc.slice(last)
+
+  // Field names: lowercase identifier at the start of a line followed by `:`.
+  out = out.replace(
+    /(^|\n)(\s+)([a-z_][a-zA-Z0-9_]*)(\s*:\s*)/gm,
+    (_full, nl: string, indent: string, name: string, colon: string) =>
+      _full.includes("sh-")
+        ? _full
+        : `${nl}${indent}${wrap("field", name)}${colon}`,
   )
 
-  // Comments
-  html = html.replace(/(#[^\n]*)/g, '<span class="sh-comment">$1</span>')
+  // Non-null `!` and list `[` `]` markers
+  out = out.replace(/(!)/g, wrap("operator", "$1"))
+  out = out.replace(/([[\]])/g, wrap("operator", "$1"))
 
-  // Directives
-  html = html.replace(
-    /(@[a-zA-Z_][a-zA-Z0-9_]*)/g,
-    '<span class="sh-directive">$1</span>',
-  )
-
-  // Scalar types
-  html = html.replace(
-    /\b(String|Int|Float|Boolean|ID)\b/g,
-    '<span class="sh-type">$1</span>',
-  )
-
-  // SDL keywords
-  html = html.replace(
-    /\b(type|input|interface|union|enum|scalar|schema|extend|implements|directive|repeatable|query|mutation|subscription|fragment|on|true|false|null)\b/g,
-    '<span class="sh-keyword">$1</span>',
-  )
-
-  // Type names (CapitalizedWords after type/extends/implements)
-  html = html.replace(
-    /(\btype\s+)([A-Z][a-zA-Z0-9_]*)/g,
-    '$1<span class="sh-type">$2</span>',
-  )
-
-  // General capitalized type references (field types)
-  html = html.replace(
-    /\b([A-Z][a-zA-Z0-9_]*)\b/g,
-    (match, typeName, offset) => {
-      const before = html.substring(Math.max(0, offset - 60), offset)
-      const alreadyWrapped =
-        before.lastIndexOf('<span class="sh-type">') >
-        before.lastIndexOf("</span>")
-      if (alreadyWrapped) return match
-      return `<span class="sh-type">${typeName}</span>`
-    },
-  )
-
-  // Field names (identifier colon pattern)
-  html = html.replace(
-    /(^|\n)(\s+)([a-zA-Z_][a-zA-Z0-9_]*)(\s*:\s*)/gm,
-    (
-      _full: string,
-      nl: string,
-      indent: string,
-      name: string,
-      colon: string,
-    ) => {
-      if (_full.includes("<span")) return _full
-      return `${nl}${indent}<span class="sh-field">${name}</span>${colon}`
-    },
-  )
-
-  // Required/non-null markers (!)
-  html = html.replace(
-    /(\s)(!)(\s|[,\n)])/g,
-    '$1<span class="sh-operator">$2</span>$3',
-  )
-
-  // List brackets
-  html = html.replace(
-    /\[([A-Za-z!]+)\]/g,
-    '<span class="sh-operator">[</span>$1<span class="sh-operator">]</span>',
-  )
-
-  return html
+  return out
 }
 
 /* ── JSON highlighting ── */
 
 export function highlightJSON(source: string): string {
-  let html = escapeHTML(source)
+  const esc = escapeHTML(source)
 
-  // Keys (property names before colon)
-  html = html.replace(
-    /("(?:\\.|[^"\\])*")(\s*:)/g,
-    '<span class="sh-field">$1</span>$2',
-  )
+  const re =
+    /("(?:\\.|[^"\\])*")(\s*:)?|(-?\d+\.?\d*(?:[eE][+-]?\d+)?)|\b(true|false|null)\b/g
 
-  // Numbers
-  html = html.replace(
-    /(:\s*)(-?\d+\.?\d*(?:[eE][+-]?\d+)?)/g,
-    '$1<span class="sh-number">$2</span>',
-  )
+  let out = ""
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(esc)) !== null) {
+    out += esc.slice(last, m.index)
+    const [full, str, colon, num, kw] = m
+    if (str && colon) out += wrap("field", str) + colon
+    else if (str) out += wrap("string", str)
+    else if (num) out += wrap("number", num)
+    else if (kw) out += wrap("keyword", kw)
+    last = m.index + full.length
+  }
+  out += esc.slice(last)
 
-  // String values
-  html = html.replace(
-    /(:\s*)("(?:\\.|[^"\\])*")/g,
-    '$1<span class="sh-string">$2</span>',
-  )
-
-  // Any remaining strings (e.g., in arrays)
-  html = html.replace(
-    /(^|[,[\s])("(?:\\.|[^"\\])*")/gm,
-    '$1<span class="sh-string">$2</span>',
-  )
-
-  // Booleans and null
-  html = html.replace(
-    /\b(true|false|null)\b/g,
-    '<span class="sh-keyword">$1</span>',
-  )
-
-  return html
+  return out
 }
 
 /* ── Bare text prompt highlighting (command style) ── */
 
 export function highlightPrompt(source: string): string {
-  const html = escapeHTML(source)
-  // Highlight the > prompt marker
-  return html.replace(/^(>[^\n]*)/gm, '<span class="sh-comment">$1</span>')
+  // Highlight `>`-prefixed prompt lines. Escape per-line so the `>` marker and
+  // any following text are both safe, then wrap the whole escaped line.
+  return source
+    .split("\n")
+    .map(line => {
+      if (!line.startsWith(">")) return escapeHTML(line)
+      return wrap("comment", escapeHTML(line))
+    })
+    .join("\n")
 }
 
 /* ── CSS utility classes for the highlight spans ──

--- a/src/app/(main)/ai/components/syntax-highlight.tsx
+++ b/src/app/(main)/ai/components/syntax-highlight.tsx
@@ -1,0 +1,314 @@
+"use client"
+
+/**
+ * Zero-dependency syntax highlighting for GraphQL and JSON.
+ * Uses Catppuccin Mocha palette — matches the [##1e1e2e] dark background.
+ *
+ * Colors:
+ *   #cba6f7 – mauve  (keywords: query, mutation, fragment, on, true, false, null)
+ *   #f9e2af – yellow (type names: Human, Starship, String, Int, etc.)
+ *   #89b4fa – blue   (field names, property keys in JSON)
+ *   #a6e3a1 – green  (strings)
+ *   #fab387 – peach  (numbers)
+ *   #6c7086 – overlay0 (comments, punctuation)
+ *   #f38ba8 – red    (directives)
+ */
+
+/* ── Shared helpers ── */
+
+function escapeHTML(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
+/* ── GraphQL query / SDL highlighting ── */
+
+export function highlightGraphQL(source: string): string {
+  let html = escapeHTML(source)
+
+  // Strings (single and double quoted)
+  html = html.replace(
+    /("(?:\\.|[^"\\])*")/g,
+    '<span class="sh-string">$1</span>',
+  )
+  html = html.replace(
+    /('(?:\\.|[^'\\])*')/g,
+    '<span class="sh-string">$1</span>',
+  )
+
+  // Block strings (triple-quoted)
+  html = html.replace(
+    /("""[\s\S]*?""")/g,
+    '<span class="sh-string">$1</span>',
+  )
+
+  // Comments
+  html = html.replace(
+    /(#[^\n]*)/g,
+    '<span class="sh-comment">$1</span>',
+  )
+
+  // Directives (@skip, @include, @deprecated)
+  html = html.replace(
+    /(@[a-zA-Z_][a-zA-Z0-9_]*)/g,
+    '<span class="sh-directive">$1</span>',
+  )
+
+  // Scalar types & built-ins (must come before general type names)
+  html = html.replace(
+    /\b(String|Int|Float|Boolean|ID)\b/g,
+    '<span class="sh-type">$1</span>',
+  )
+
+  // GraphQL keywords
+  html = html.replace(
+    /\b(query|mutation|subscription|fragment|on|true|false|null|type|input|interface|union|enum|scalar|schema|extend|implements|directive|repeatable)\b/g,
+    '<span class="sh-keyword">$1</span>',
+  )
+
+  // ... on Type (inline fragment)
+  html = html.replace(
+    /(\.\.\.\s+on\s+)([A-Z][a-zA-Z0-9_]*)/g,
+    '<span class="sh-operator">$1</span><span class="sh-type">$2</span>',
+  )
+
+  // Standalone type names (Capitalized words that follow whitespace + are standalone)
+  html = html.replace(
+    /\b([A-Z][a-zA-Z0-9_]+)\b/g,
+    (match, typeName, offset) => {
+      // Check if this is already wrapped in a span
+      const before = html.substring(Math.max(0, offset - 60), offset)
+      const alreadyWrapped =
+        before.lastIndexOf('<span class="sh-type">') >
+        before.lastIndexOf('</span>')
+      if (alreadyWrapped) return match
+      return `<span class="sh-type">${typeName}</span>`
+    },
+  )
+
+  // Field names at line start (unquoted identifiers followed by : or ()
+  html = html.replace(
+    /(^|\n)(\s*)([a-zA-Z_][a-zA-Z0-9_]*)(\s*)([:(])/gm,
+    (
+      _full: string,
+      nl: string,
+      indent: string,
+      name: string,
+      gap: string,
+      paren: string,
+    ) => {
+      // Don't highlight if already inside a span
+      if (
+        _full.includes('<span') ||
+        /^(query|mutation|subscription|fragment|type|input|interface|union|enum|scalar|schema|extend|implements|directive)$/.test(
+          name,
+        )
+      ) {
+        return _full
+      }
+      return `${nl}${indent}<span class="sh-field">${name}</span>${gap}${paren}`
+    },
+  )
+
+  // Nested field names (indented identifiers followed by space + {)
+  html = html.replace(
+    /(^|\n)(\s+)([a-zA-Z_][a-zA-Z0-9_]*)(\s*\{)/gm,
+    (
+      _full: string,
+      nl: string,
+      indent: string,
+      name: string,
+      brace: string,
+    ) => {
+      if (_full.includes('<span') || /^(query|mutation|subscription|fragment|on)$/.test(name)) {
+        return _full
+      }
+      return `${nl}${indent}<span class="sh-field">${name}</span>${brace}`
+    },
+  )
+
+  // Arguments: parens and colons
+  html = html.replace(
+    /([a-zA-Z_][a-zA-Z0-9_]*)(\s*:)(\s*)/g,
+    (
+      _full: string,
+      name: string,
+      colon: string,
+      space: string,
+    ) => {
+      if (_full.includes('<span')) return _full
+      return `<span class="sh-arg">${name}</span>${colon}${space}`
+    },
+  )
+
+  return html
+}
+
+/* ── GraphQL SDL (schema definition language) highlighting ── */
+
+export function highlightGraphQLSchema(source: string): string {
+  let html = escapeHTML(source)
+
+  // Strings
+  html = html.replace(
+    /("(?:\\.|[^"\\])*")/g,
+    '<span class="sh-string">$1</span>',
+  )
+
+  // Comments
+  html = html.replace(
+    /(#[^\n]*)/g,
+    '<span class="sh-comment">$1</span>',
+  )
+
+  // Directives
+  html = html.replace(
+    /(@[a-zA-Z_][a-zA-Z0-9_]*)/g,
+    '<span class="sh-directive">$1</span>',
+  )
+
+  // Scalar types
+  html = html.replace(
+    /\b(String|Int|Float|Boolean|ID)\b/g,
+    '<span class="sh-type">$1</span>',
+  )
+
+  // SDL keywords
+  html = html.replace(
+    /\b(type|input|interface|union|enum|scalar|schema|extend|implements|directive|repeatable|query|mutation|subscription|fragment|on|true|false|null)\b/g,
+    '<span class="sh-keyword">$1</span>',
+  )
+
+  // Type names (CapitalizedWords after type/extends/implements)
+  html = html.replace(
+    /(\btype\s+)([A-Z][a-zA-Z0-9_]*)/g,
+    '$1<span class="sh-type">$2</span>',
+  )
+
+  // General capitalized type references (field types)
+  html = html.replace(
+    /\b([A-Z][a-zA-Z0-9_]*)\b/g,
+    (match, typeName, offset) => {
+      const before = html.substring(Math.max(0, offset - 60), offset)
+      const alreadyWrapped =
+        before.lastIndexOf('<span class="sh-type">') >
+        before.lastIndexOf('</span>')
+      if (alreadyWrapped) return match
+      return `<span class="sh-type">${typeName}</span>`
+    },
+  )
+
+  // Field names (identifier colon pattern)
+  html = html.replace(
+    /(^|\n)(\s+)([a-zA-Z_][a-zA-Z0-9_]*)(\s*:\s*)/gm,
+    (
+      _full: string,
+      nl: string,
+      indent: string,
+      name: string,
+      colon: string,
+    ) => {
+      if (_full.includes('<span')) return _full
+      return `${nl}${indent}<span class="sh-field">${name}</span>${colon}`
+    },
+  )
+
+  // Required/non-null markers (!)
+  html = html.replace(
+    /(\s)(!)(\s|[,\n)])/g,
+    '$1<span class="sh-operator">$2</span>$3',
+  )
+
+  // List brackets
+  html = html.replace(
+    /\[([A-Za-z!]+)\]/g,
+    '<span class="sh-operator">[</span>$1<span class="sh-operator">]</span>',
+  )
+
+  return html
+}
+
+/* ── JSON highlighting ── */
+
+export function highlightJSON(source: string): string {
+  let html = escapeHTML(source)
+
+  // Keys (property names before colon)
+  html = html.replace(
+    /("(?:\\.|[^"\\])*")(\s*:)/g,
+    '<span class="sh-field">$1</span>$2',
+  )
+
+  // Numbers
+  html = html.replace(
+    /(:\s*)(-?\d+\.?\d*(?:[eE][+-]?\d+)?)/g,
+    '$1<span class="sh-number">$2</span>',
+  )
+
+  // String values
+  html = html.replace(
+    /(:\s*)("(?:\\.|[^"\\])*")/g,
+    '$1<span class="sh-string">$2</span>',
+  )
+
+  // Any remaining strings (e.g., in arrays)
+  html = html.replace(
+    /(^|[,[\s])("(?:\\.|[^"\\])*")/gm,
+    '$1<span class="sh-string">$2</span>',
+  )
+
+  // Booleans and null
+  html = html.replace(
+    /\b(true|false|null)\b/g,
+    '<span class="sh-keyword">$1</span>',
+  )
+
+  return html
+}
+
+/* ── Bare text prompt highlighting (command style) ── */
+
+export function highlightPrompt(source: string): string {
+  const html = escapeHTML(source)
+  // Highlight the > prompt marker
+  return html.replace(
+    /^(>[^\n]*)/gm,
+    '<span class="sh-comment">$1</span>',
+  )
+}
+
+/* ── CSS utility classes for the highlight spans ──
+   Include these once in any parent that uses highlighted code.  ── */
+
+export const syntaxColors = {
+  comment:  "#6c7086",
+  keyword:  "#cba6f7",
+  type:     "#f9e2af",
+  field:    "#89b4fa",
+  string:   "#a6e3a1",
+  number:   "#fab387",
+  directive:"#f38ba8",
+  operator: "#94e2d5",
+  arg:      "#89dceb",
+} as const
+
+/**
+ * CSS string to inject once per page (or rely on Tailwind arbitrary values).
+ * Exporting as a constant so consumers can use dangerouslySetInnerHTML with <style>.
+ */
+export const SYNTAX_CSS = `
+.sh-comment  { color: ${syntaxColors.comment};  font-style: italic; }
+.sh-keyword  { color: ${syntaxColors.keyword};  }
+.sh-type     { color: ${syntaxColors.type};     }
+.sh-field    { color: ${syntaxColors.field};    }
+.sh-string   { color: ${syntaxColors.string};   }
+.sh-number   { color: ${syntaxColors.number};   }
+.sh-directive{ color: ${syntaxColors.directive};}
+.sh-operator { color: ${syntaxColors.operator}; }
+.sh-arg      { color: ${syntaxColors.arg};      }
+/* Code blocks use a fixed dark background (Catppuccin Mocha #1e1e2e) in both
+   light and dark mode, so base text must be light regardless of theme. */
+pre { color: #cdd6f4; }
+`

--- a/src/app/(main)/ai/components/use-cases.tsx
+++ b/src/app/(main)/ai/components/use-cases.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+import { SectionLabel } from "@/app/conf/_design-system/section-label"
+import { Button } from "@/app/conf/_design-system/button"
+import ArrowDownIcon from "@/app/conf/_design-system/pixelarticons/arrow-down.svg?svgr"
+import MCPIcon from "@/app/conf/_design-system/pixelarticons/modem.svg?svgr"
+import SearchIcon from "@/app/conf/_design-system/pixelarticons/search.svg?svgr"
+import CodeIcon from "@/app/conf/_design-system/pixelarticons/code.svg?svgr"
+import { highlightGraphQL, SYNTAX_CSS } from "./syntax-highlight"
+
+const useCases = [
+  {
+    icon: MCPIcon,
+    title: "MCP Servers",
+    description:
+      "Build Model Context Protocol servers powered by GraphQL. Every query, mutation, and subscription becomes an auto-discoverable tool. Zero hand-written tool definitions — the schema is the contract.",
+    bullets: [
+      "Auto-generate tool definitions from schema",
+      "Type-safe inputs and structured outputs",
+      "One MCP server exposes your entire API surface",
+    ],
+    code: `# AI agent discovers and calls tools
+query {
+  tools {
+    name
+    description
+    parameters {
+      name
+      type
+    }
+  }
+}
+mutation {
+  callTool(
+    name: "searchProducts"
+    params: { query: "laptop" }
+  )
+}`,
+    highlight: highlightGraphQL,
+    href: "/blog/2025-10-14-announcing-ai-wg/",
+    cta: "Join the AI Working Group",
+  },
+  {
+    icon: SearchIcon,
+    title: "RAG Applications",
+    description:
+      "Power Retrieval-Augmented Generation with GraphQL. Query your knowledge base with precision — fetch documents, embeddings, and cross-references in a single request. No more REST pagination + client-side merging.",
+    bullets: [
+      "Fetch documents + embeddings in one call",
+      "Join data across collections and sources",
+      "Minimize context window waste with field selection",
+    ],
+    code: `{
+  search(term: "MCP protocol") {
+    documents {
+      title
+      excerpt
+      embeddings {
+        vector
+        similarity
+      }
+    }
+    relatedTopics {
+      name
+    }
+  }
+}`,
+    highlight: highlightGraphQL,
+    href: "/resources/ai",
+    cta: "Explore AI resources",
+  },
+  {
+    icon: CodeIcon,
+    title: "AI Agents & Tool Calling",
+    description:
+      "Give AI agents structured, type-safe access to your data layer. GraphQL's query composition lets LLMs build complex, multi-step data fetches in a single round-trip — calling multiple services, filtering, and aggregating.",
+    bullets: [
+      "Agents compose queries at inference time",
+      "Real-time subscriptions for streaming agents",
+      "Single endpoint for all data operations",
+    ],
+    code: `{
+  orders(status: PENDING) {
+    customer {
+      name
+      email
+    }
+    items {
+      product {
+        name
+        stock
+      }
+    }
+    total
+  }
+}`,
+    highlight: highlightGraphQL,
+    href: "/blog/2025-07-03-graphql-supercharging-ai/",
+    cta: "Read the blog post",
+  },
+]
+
+export function UseCases() {
+  return (
+    <section className="gql-container gql-section lg:py-16 xl:py-24">
+      <SectionLabel className="mb-6">Use cases</SectionLabel>
+      <style dangerouslySetInnerHTML={{ __html: SYNTAX_CSS }} />
+      <h2 className="typography-h2 mb-2 lg:mb-4">
+        GraphQL powers
+        <br />
+        the AI stack
+      </h2>
+      <p className="typography-body-lg mb-8 max-w-2xl text-pretty text-neu-800 lg:mb-16">
+        From MCP servers to RAG pipelines to autonomous agents, GraphQL is
+        already the protocol of choice for connecting AI systems to real data.
+      </p>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {useCases.map(useCase => (
+          <div
+            key={useCase.title}
+            className="flex flex-col rounded-xl border border-neu-200 bg-neu-0 p-6 transition-shadow hover:shadow-lg dark:border-neu-100 lg:p-7"
+          >
+            <div className="flex items-center gap-3">
+              <useCase.icon className="size-7 text-pri-base" />
+              <h3 className="typography-h4">{useCase.title}</h3>
+            </div>
+            <p className="typography-body-md mt-3 flex-1 text-pretty text-neu-800">
+              {useCase.description}
+            </p>
+
+            {/* Code example */}
+            <div className="mt-5 overflow-hidden rounded-lg border border-neu-200 bg-[#1e1e2e] dark:border-neu-100">
+              <div className="border-b border-neu-100/10 px-3 py-1.5">
+                <span className="font-mono text-[11px] text-[#6c7086]">
+                  Example query
+                </span>
+              </div>
+              <pre className="overflow-x-auto p-3 font-mono text-[11px] leading-relaxed">
+                <code
+                  className="whitespace-pre-wrap"
+                  dangerouslySetInnerHTML={{
+                    __html: useCase.highlight(useCase.code),
+                  }}
+                />
+              </pre>
+            </div>
+
+            <ul className="typography-body-sm mt-5 flex flex-col gap-1.5">
+              {useCase.bullets.map(bullet => (
+                <li
+                  key={bullet}
+                  className="flex items-start gap-1.5 text-neu-700"
+                >
+                  <span className="mt-1.5 size-1 shrink-0 rounded-full bg-pri-base" />
+                  {bullet}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-auto pt-5">
+              <Button href={useCase.href} variant="secondary" size="md">
+                {useCase.cta}
+                <ArrowDownIcon className="size-4 shrink-0 -rotate-90 text-neu-900" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/app/(main)/ai/components/why-graphql-ai.tsx
+++ b/src/app/(main)/ai/components/why-graphql-ai.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { SectionLabel } from "@/app/conf/_design-system/section-label"
+import CheckIcon from "@/app/conf/_design-system/pixelarticons/check.svg?svgr"
+import SearchIcon from "@/app/conf/_design-system/pixelarticons/search.svg?svgr"
+import ZapIcon from "@/app/conf/_design-system/pixelarticons/zap.svg?svgr"
+import SlidersIcon from "@/app/conf/_design-system/pixelarticons/sliders.svg?svgr"
+import { highlightGraphQL, highlightGraphQLSchema, SYNTAX_CSS } from "./syntax-highlight"
+
+const benefits = [
+  {
+    title: "Self-describing",
+    eyebrow: "Introspection",
+    icon: SearchIcon,
+    description:
+      "Every GraphQL API ships with a built-in type system. AI agents query `__schema` and immediately understand what data is available, what arguments each field accepts, and how types relate — no hand-written tool descriptions needed.",
+    bullets: [
+      "Auto-generated tool definitions for LLMs",
+      "Agents discover capabilities at runtime",
+      "Zero-config MCP server from any GraphQL endpoint",
+    ],
+    code: `# Agent introspects your API
+query {
+  __schema {
+    types {
+      name
+      fields {
+        name
+      }
+    }
+  }
+}`,
+    highlight: highlightGraphQL as (s: string) => string,
+  },
+  {
+    title: "Strongly typed",
+    eyebrow: "Type Safety",
+    icon: ZapIcon,
+    description:
+      "Every field has a known, validated type. LLMs can reason about inputs and outputs with confidence. Structured, predictable responses eliminate parsing errors and prevent hallucinated API calls that plague unstructured REST endpoints.",
+    bullets: [
+      "LLMs understand data shapes natively",
+      "Validated responses prevent parsing errors",
+      "Type system reduces hallucinated API interactions",
+    ],
+    code: `# Every field has a known type
+type Query {
+  human(id: ID!): Human
+}
+type Human {
+  name: String!
+  height(unit: Unit): Float
+}`,
+    highlight: highlightGraphQLSchema as (s: string) => string,
+  },
+  {
+    title: "Composable",
+    eyebrow: "Flexibility",
+    icon: SlidersIcon,
+    description:
+      "Request exactly what you need, nothing more. GraphQL lets AI agents compose precise queries on the fly — requesting nested data, using aliases, and applying filters. One endpoint serves any data access pattern without client-side stitching.",
+    bullets: [
+      "Up to 90% less token usage vs equivalent REST",
+      "Dynamic query composition by AI agents",
+      "Single endpoint replaces dozens of REST routes",
+    ],
+    code: `# Agent fetches related data in 1 call
+{
+  human(id: "1000") {
+    name
+    friends {
+      name
+      starships {
+        name
+      }
+    }
+  }
+}`,
+    highlight: highlightGraphQL as (s: string) => string,
+  },
+]
+
+export function WhyGraphQLAI() {
+  return (
+    <section className="gql-container gql-section lg:py-16 xl:py-24">
+      <SectionLabel className="mb-6">Why GraphQL for AI</SectionLabel>
+      <h2 className="typography-h2 mb-2 lg:mb-4">
+        Built for machines
+        <br />
+        to understand
+      </h2>
+      <p className="typography-body-lg mb-8 max-w-2xl text-pretty text-neu-800 lg:mb-16">
+        GraphQL was designed from day one to be machine-readable. Its
+        introspection system, type safety, and composability are the same
+        properties that make it the ideal protocol for AI-agent-to-API
+        communication.
+      </p>
+
+      <style dangerouslySetInnerHTML={{ __html: SYNTAX_CSS }} />
+      <div className="grid gap-px bg-neu-200 dark:bg-neu-100 lg:grid-cols-3">
+        {benefits.map(benefit => (
+          <div
+            key={benefit.eyebrow}
+            className="flex flex-col bg-neu-0 p-6 lg:p-8 xl:p-10"
+          >
+            <div className="flex items-center gap-3">
+              <benefit.icon className="size-6 text-pri-base" />
+              <span className="typography-body-sm w-fit bg-sec-light px-2 py-0.5 font-medium dark:bg-sec-darker">
+                {benefit.eyebrow}
+              </span>
+            </div>
+            <h3 className="typography-h3 mt-4">{benefit.title}</h3>
+            <p className="typography-body-md mt-4 flex-1 text-pretty text-neu-800">
+              {benefit.description}
+            </p>
+
+            {/* Code preview */}
+            <div className="mt-5 overflow-hidden rounded-lg border border-neu-200 bg-[#1e1e2e] dark:border-neu-100">
+              <pre className="overflow-x-auto p-3 font-mono text-xs leading-relaxed">
+                <code
+                  dangerouslySetInnerHTML={{
+                    __html: benefit.highlight(benefit.code),
+                  }}
+                />
+              </pre>
+            </div>
+
+            <ul className="typography-body-sm mt-5 flex flex-col gap-2">
+              {benefit.bullets.map(bullet => (
+                <li key={bullet} className="flex items-start gap-1.5">
+                  <CheckIcon className="mt-0.5 size-3.5 shrink-0 text-pri-base" />
+                  <span className="text-neu-700">{bullet}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/app/(main)/ai/components/why-graphql-ai.tsx
+++ b/src/app/(main)/ai/components/why-graphql-ai.tsx
@@ -5,7 +5,11 @@ import CheckIcon from "@/app/conf/_design-system/pixelarticons/check.svg?svgr"
 import SearchIcon from "@/app/conf/_design-system/pixelarticons/search.svg?svgr"
 import ZapIcon from "@/app/conf/_design-system/pixelarticons/zap.svg?svgr"
 import SlidersIcon from "@/app/conf/_design-system/pixelarticons/sliders.svg?svgr"
-import { highlightGraphQL, highlightGraphQLSchema, SYNTAX_CSS } from "./syntax-highlight"
+import {
+  highlightGraphQL,
+  highlightGraphQLSchema,
+  SYNTAX_CSS,
+} from "./syntax-highlight"
 
 const benefits = [
   {

--- a/src/app/(main)/ai/page.tsx
+++ b/src/app/(main)/ai/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
   description:
     "Discover how GraphQL's self-describing schemas, strong typing, and composability make it the ideal API protocol for AI systems, MCP servers, and LLM-powered applications.",
   openGraph: {
-    title: "GraphQL & AI — The API protocol for intelligent systems",
+    title: "GraphQL & AI — The API language for humans and agents",
     description:
       "When AI agents need to interact with APIs, GraphQL's self-describing schemas, strong typing, and composable queries make it the natural choice.",
   },

--- a/src/app/(main)/ai/page.tsx
+++ b/src/app/(main)/ai/page.tsx
@@ -1,0 +1,35 @@
+import { Metadata } from "next"
+import { NavbarFixed } from "@/components/navbar/navbar-fixed"
+import { Hero } from "./components/hero"
+import { WhyGraphQLAI } from "./components/why-graphql-ai"
+import { ByTheNumbers } from "./components/by-the-numbers"
+import { InteractiveDemo } from "./components/interactive-demo"
+import { HowItWorks } from "./components/how-it-works"
+import { UseCases } from "./components/use-cases"
+import { CTACommunity } from "./components/cta-community"
+
+export const metadata: Metadata = {
+  title: "GraphQL & AI",
+  description:
+    "Discover how GraphQL's self-describing schemas, strong typing, and composability make it the ideal API protocol for AI systems, MCP servers, and LLM-powered applications.",
+  openGraph: {
+    title: "GraphQL & AI — The API protocol for intelligent systems",
+    description:
+      "When AI agents need to interact with APIs, GraphQL's self-describing schemas, strong typing, and composable queries make it the natural choice.",
+  },
+}
+
+export default function AIPage() {
+  return (
+    <main className="gql-all-anchors-focusable bg-neu-0">
+      <NavbarFixed />
+      <Hero />
+      <WhyGraphQLAI />
+      <ByTheNumbers />
+      <InteractiveDemo />
+      <HowItWorks />
+      <UseCases />
+      <CTACommunity />
+    </main>
+  )
+}

--- a/src/globals.css
+++ b/src/globals.css
@@ -3,6 +3,17 @@
 @import "tailwindcss/utilities";
 @import "tailwindcss/components";
 
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/src/pages/_meta.tsx
+++ b/src/pages/_meta.tsx
@@ -108,6 +108,15 @@ export default {
       layout: "raw",
     },
   },
+  ai: {
+    type: "page",
+    title: (
+      <Emphasis>
+        GraphQL & AI
+      </Emphasis>
+    ),
+    href: "/ai",
+  },
   conf: {
     type: "page",
     title: (

--- a/src/pages/_meta.tsx
+++ b/src/pages/_meta.tsx
@@ -110,11 +110,7 @@ export default {
   },
   ai: {
     type: "page",
-    title: (
-      <Emphasis>
-        GraphQL & AI
-      </Emphasis>
-    ),
+    title: <Emphasis>GraphQL & AI</Emphasis>,
     href: "/ai",
   },
   conf: {

--- a/src/pages/_meta.tsx
+++ b/src/pages/_meta.tsx
@@ -110,7 +110,7 @@ export default {
   },
   ai: {
     type: "page",
-    title: <Emphasis>GraphQL & AI</Emphasis>,
+    title: <AIEmphasis>AI</AIEmphasis>,
     href: "/ai",
   },
   conf: {
@@ -145,6 +145,13 @@ function Emphasis({ children }: { children: React.ReactNode }) {
 function DayEmphasis({ children }: { children: React.ReactNode }) {
   return (
     <span className="relative block before:absolute before:-inset-x-3 before:-inset-y-1 before:border before:border-current [a:has(>&)]:text-emerald-600 dark:[a:has(>&)]:text-emerald-400 [a:hover:has(>&)]:no-underline [a:hover_&]:before:border-transparent">
+      {children}
+    </span>
+  )
+}
+function AIEmphasis({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="relative block rounded-full bg-pri-base/15 px-2 py-0.5 text-[0.7rem] font-bold uppercase tracking-wide text-pri-dark dark:bg-pri-light/20 dark:text-pri-light [a:has(>&)]:no-underline">
       {children}
     </span>
   )


### PR DESCRIPTION
New /ai route showcasing GraphQL for AI systems (MCP servers, RAG, agents & tool calling). Includes hero with canvas particle network, interactive Star Wars GraphQL demo executing real queries client-side, syntax-highlighted code blocks, by-the-numbers stats, and CTA.

- src/app/(main)/ai/: page + 9 components (hero, interactive-demo, how-it-works, why-graphql-ai, use-cases, by-the-numbers, cta-community, syntax-highlight)
- src/pages/_meta.tsx: add 'ai' nav entry pointing to /ai
- src/globals.css: add @keyframes fadeInUp used by interactive demo
- package.json + pnpm-lock.yaml: add sharp dependency

<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

Closes #<issue number>

## Description

<!-- Write a brief description of the changes introduced by this PR -->
