### PR TITLE
Add slides filter to conference schedule

### DIFF
--- a/src/app/conf/2026/_data.ts
+++ b/src/app/conf/2026/_data.ts
@@ -6,11 +6,13 @@ import { readSpeakers } from "../_api/sched-data"
 const speakersData = require("../../../../scripts/sync-sched/speakers.json")
 const equalitySets: string[][] = speakersData.equal || []
 
-export const schedule: ScheduleSession[] = require("../../../../scripts/sync-sched/schedule-2026.json")
- .map((session: ScheduleSession) => ({
-    ...session,
-    hasSlides: session.files?.length ? "Yes" : "No",
-  }))
+export const schedule: ScheduleSession[] =
+  require("../../../../scripts/sync-sched/schedule-2026.json").map(
+    (session: ScheduleSession) => ({
+      ...session,
+      hasSlides: session.files?.length ? "Yes" : "No",
+    }),
+  )
 
 type SpeakerUsername = SchedSpeaker["username"]
 

--- a/src/app/conf/2026/_data.ts
+++ b/src/app/conf/2026/_data.ts
@@ -7,6 +7,10 @@ const speakersData = require("../../../../scripts/sync-sched/speakers.json")
 const equalitySets: string[][] = speakersData.equal || []
 
 export const schedule: ScheduleSession[] = require("../../../../scripts/sync-sched/schedule-2026.json")
+ .map((session: ScheduleSession) => ({
+    ...session,
+    hasSlides: session.files?.length ? "Yes" : "No",
+  }))
 
 type SpeakerUsername = SchedSpeaker["username"]
 

--- a/src/app/conf/2026/schedule/page.tsx
+++ b/src/app/conf/2026/schedule/page.tsx
@@ -16,6 +16,7 @@ const FILTERS: FiltersConfig = {
   event_type: "Session Format",
   event_subtype: "Talk Category",
   audience: "Audience",
+  hasSlides: "Slides",
 }
 
 export const metadata: Metadata = {

--- a/src/app/conf/_api/sched-types.ts
+++ b/src/app/conf/_api/sched-types.ts
@@ -18,6 +18,7 @@ export type ScheduleSession = {
   company: string
   speakers?: SchedSpeaker[]
   files?: { name: string; path: string }[]
+  hasSlides?: "Yes" | "No"
 }
 
 export type SchedSpeaker = {
@@ -36,6 +37,7 @@ export type SchedSpeaker = {
   ["~syncedDetailsAt"]?: number
   /* added on export, merged on conflict */
   _years: ConferenceYear[]
+  
 }
 
 export type ConferenceYear = 2026 | 2025 | 2024 | 2023

--- a/src/app/conf/_api/sched-types.ts
+++ b/src/app/conf/_api/sched-types.ts
@@ -37,7 +37,6 @@ export type SchedSpeaker = {
   ["~syncedDetailsAt"]?: number
   /* added on export, merged on conflict */
   _years: ConferenceYear[]
-  
 }
 
 export type ConferenceYear = 2026 | 2025 | 2024 | 2023


### PR DESCRIPTION
Closes #2420

## Description

This PR adds support for filtering conference sessions based on whether presentation slides are attached.

### Changes

- Added a `hasSlides` property to `ScheduleSession`
- Derived the `hasSlides` value from the existing `session.files` data
- Added a **Slides** filter to the conference schedule
- Reused the existing generic filtering mechanism without introducing additional filtering logic

### Testing

- Verified that the **Slides** filter appears in the conference schedule
- Verified that sessions with attached files appear under **Yes**
- Verified that sessions without attached files appear under **No**
- Confirmed that the filter works alongside the existing schedule filters

### Screenshot

The new **Slides** filter with **Yes/No** options in the conference schedule.

<img width="2047" height="1177" alt="graphql_slides_filter" src="https://github.com/user-attachments/assets/d7a03055-c725-437b-8dce-59b4787f5b4c" />

