### PR TITLE
Fix formatting and improve clarity in schema.mdx

### DIFF
--- a/src/pages/learn/schema.mdx
+++ b/src/pages/learn/schema.mdx
@@ -186,8 +186,6 @@ type Character {
 
 Here, we're using a `String` type and marking it as a Non-Null type by adding an exclamation mark (`!`) after the type name. This means that our server always expects to return a non-null value for this field, and if the resolver produces a null value, then that will trigger a GraphQL execution error, letting the client know that something has gone wrong.
 
-As we saw in an example above, the Non-Null type modifier can also be used when defining arguments for a field, which will cause the GraphQL server to return a validation error if a null value is passed as that argument:
-
 ```graphql
 # { "graphiql": true }
 {
@@ -196,6 +194,7 @@ As we saw in an example above, the Non-Null type modifier can also be used when 
   }
 }
 ```
+As we saw in an example above, the Non-Null type modifier can also be used when defining arguments for a field, which will cause the GraphQL server to return a validation error if a null value is passed as that argument:
 
 ### List
 


### PR DESCRIPTION


<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->
## Description

<!-- Write a brief description of the changes introduced by this PR -->
The text for the example for `null` argument is in the wrong place. Notice it says `As we saw in the example above`, even though the example it is referring to is below.