### PR TITLE
Fix navigator access during server-side rendering

### DIFF
--- a/src/app/conf/2026/schedule/[id]/page.tsx
+++ b/src/app/conf/2026/schedule/[id]/page.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/app/conf/_design-system/button"
 import { SessionTags } from "../../components/session-tags"
 import { formatDescription } from "./format-description"
 import { formatBlockTime } from "../_components/format-block-time"
+import { PdfPreview } from "./pdf-preview"
 import DownloadIcon from "@/app/conf/_design-system/pixelarticons/download.svg?svgr"
 
 type SessionProps = { params: { id: string } }
@@ -127,12 +128,7 @@ export default function SessionPage({ params }: SessionProps) {
                     <ul className="flex max-w-full flex-col gap-y-2">
                       {session.files?.map(({ path, name }) => (
                         <li key={path}>
-                          {path.endsWith(".pdf") && canRenderPdf() ? (
-                            <iframe
-                              src={path}
-                              className="aspect-video size-full"
-                            />
-                          ) : null}
+                          {path.endsWith(".pdf") && <PdfPreview path={path} />}
                           <div className="flex items-stretch justify-between overflow-hidden">
                             <a
                               className="typography-link flex items-center truncate p-3 leading-none text-neu-700 max-xs:hidden sm:px-6"
@@ -296,10 +292,4 @@ function SessionDescription({ session }: { session: ScheduleSession }) {
       />
     </div>
   )
-}
-
-const isFirefox = navigator.userAgent.toLowerCase().includes("firefox")
-
-function canRenderPdf() {
-  return !isFirefox && !!navigator?.mimeTypes?.["application/pdf" as any]
 }

--- a/src/app/conf/2026/schedule/[id]/pdf-preview.tsx
+++ b/src/app/conf/2026/schedule/[id]/pdf-preview.tsx
@@ -7,7 +7,9 @@ export function PdfPreview({ path }: { path: string }) {
 
   useEffect(() => {
     const isFirefox = navigator.userAgent.toLowerCase().includes("firefox")
-    setCanRender(!isFirefox && !!navigator?.mimeTypes?.["application/pdf" as any])
+    setCanRender(
+      !isFirefox && !!navigator?.mimeTypes?.["application/pdf" as any],
+    )
   }, [])
 
   if (!canRender) return null

--- a/src/app/conf/2026/schedule/[id]/pdf-preview.tsx
+++ b/src/app/conf/2026/schedule/[id]/pdf-preview.tsx
@@ -1,0 +1,15 @@
+// pdf-preview.tsx
+"use client"
+import { useEffect, useState } from "react"
+
+export function PdfPreview({ path }: { path: string }) {
+  const [canRender, setCanRender] = useState(false)
+
+  useEffect(() => {
+    const isFirefox = navigator.userAgent.toLowerCase().includes("firefox")
+    setCanRender(!isFirefox && !!navigator?.mimeTypes?.["application/pdf" as any])
+  }, [])
+
+  if (!canRender) return null
+  return <iframe src={path} className="aspect-video size-full" />
+}


### PR DESCRIPTION
Closes #2471.

Moves the PDF preview into a dedicated client component so browser-specific APIs (`navigator`) are no longer accessed during server-side rendering while preserving the existing PDF preview behavior.

## Changes

- Extracted PDF preview into a dedicated client component.
- Removed browser-only logic from the server-rendered page.
- Preserved the existing PDF preview behavior.

## Testing

- Verified the session detail page renders correctly in development.
- Verified `pnpm build` completes successfully.
- Confirmed PDF previews continue to render in supported browsers.
