### PR TITLE
Add Turbofy to GraphQL services

### DIFF
--- a/src/code/services/turbofy.md
+++ b/src/code/services/turbofy.md
@@ -1,0 +1,11 @@
+---
+name: Turbofy®
+description: Turbofy® is an AI-assisted low-code platform for building and launching data-driven web applications. Each workspace can expose a [GraphQL Developer API](https://docs.turbofy.com/en/api) generated automatically from its schema, with typed queries and mutations, real-time subscriptions, an integrated GraphQL Playground, and per-table access controls. Teams can define data models, compose reusable UI building blocks, and connect external apps and integrations without writing or operating a backend.
+url: https://turbofy.com
+tags:
+  - tools-and-libraries
+  - tools
+  - frontend
+  - backend
+  - ai
+---


### PR DESCRIPTION
## Description

Add Turbofy - an API-first vibe-coding platform with a GraphQL playground for their embedded GraphQL workspace API - to the GraphQL.org Tools & Libraries directory and the frontend, backend, and AI resource hubs.