### PR TITLE
Let the working groups scrollview scroll

### DIFF
--- a/src/app/(main)/resources/[category]/category-working-groups.tsx
+++ b/src/app/(main)/resources/[category]/category-working-groups.tsx
@@ -58,10 +58,7 @@ export async function CategoryWorkingGroups({
         </Button>
       </header>
       <EventsScrollview
-        className={clsx(
-          "mt-4 !max-w-[unset] lg:mt-10",
-          events.length < 4 && "!grid-rows-1",
-        )}
+        className={clsx("mt-4 lg:mt-10", events.length < 4 && "!grid-rows-1")}
       >
         {events.map(event => (
           <EventCard


### PR DESCRIPTION
The working groups row on the resource category pages doesn't scroll. It
stretches the whole document instead, so every page below it gets a
horizontal scrollbar.

`EventsScrollview` is a `w-fit` grid with `max-w-full`, which is what makes
it clamp to its container and lets `overflow-auto` take over. The category
pages passed `!max-w-[unset]` in, so the grid sized itself to every card and
`overflow-auto` had nothing left to scroll.

Measured at a 1280px viewport:

| Page | `document.scrollWidth` before | after |
| --- | --- | --- |
| `/resources/ai` | 3052px | 1280px |
| `/resources/federation` | 11016px | 1280px |

`/community/events` already uses the scrollview without the override, so this
just brings the category pages in line with it. Checked all six categories;
the two with a working group row now scroll, the other four are unaffected.