### PR TITLE
Add Foundgine to .NET server tools

### DIFF
--- a/src/code/language-support/c-net/server/foundgine.md
+++ b/src/code/language-support/c-net/server/foundgine.md
@@ -1,0 +1,38 @@
+---
+name: Foundgine
+description: A semantic execution layer for .NET with a Hot Chocolate adapter that translates GraphQL queries into authorized, provider-independent execution plans.
+url: https://cristianbarragan.github.io/Foundgine/docs-site/index.html
+github: CristianBarragan/Foundgine
+tags:
+  - tools-and-libraries
+  - backend
+  - ai
+---
+
+Foundgine.GraphQL.HotChocolate is a Hot Chocolate adapter that translates incoming GraphQL query syntax into Foundgine's provider-neutral semantic requests:
+
+```text
+GraphQL → AST → Semantic Request → Foundgine runtime
+```
+
+The adapter parses the GraphQL document (fields, aliases, fragments, directives, variables), resolves the root field against Foundgine's semantic model, and hands off a structured request — GraphQL syntax never leaks past this boundary.
+
+```csharp
+var adapter = new HotChocolateSemanticAdapter(semanticModel);
+
+var request = adapter.Adapt(
+    graphql: """
+        query {
+          product(sku: "SKU-1") {
+            name
+            catalog { category }
+            inventory(available: true) { quantity }
+            pricing { amount currency }
+          }
+        }
+        """);
+
+var result = await foundgineRuntime.ExecuteAsync(request);
+```
+
+Foundgine resolves the request against the application's semantic model, applies authorization, builds a provider-independent execution plan, and executes it — the same rules and capabilities used by GraphQL are also available to REST, automation, and AI agent callers, without duplicating validation or authorization logic per caller.


### PR DESCRIPTION
<!--
  Thanks for making a pull request!

  Before submitting, please read our contributing guidelines:
  https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md

  Have any questions?
  Feel free to ask in this PR or you can also find us on the #website channel on the GraphQL Slack (invite link available in CONTRIBUTING.md)
-->

## Description

## Add Foundgine to .NET server tools

This PR adds **Foundgine** to the GraphQL.org .NET server/tooling listings.

Foundgine is a semantic execution layer for .NET that composes application entities, relationships, and capabilities into authorized, executable operations.

The example demonstrates a product composed from four entities:

```text
Product
 ├── Catalog
 ├── Inventory
 ├── Pricing
 └── Reviews
```

It also highlights Foundgine's dynamic capability model, where callers can compose operations from available semantic capabilities rather than requiring a separate hard-coded endpoint for every combination.

### Why this belongs in the GraphQL ecosystem

Foundgine is complementary to GraphQL rather than a replacement for it. GraphQL can provide the client-facing API while Foundgine provides the semantic execution layer behind the API.

The same application capabilities can also be consumed by APIs, automation, and AI agents.

### Key capabilities demonstrated

* Composable entities and relationships
* Dynamic capability composition
* Structured application intent
* Authorization-aware execution
* Provider-independent execution planning
* Integration with GraphQL and other callers

The page follows the existing GraphQL.org tooling page format and keeps the description intentionally concise.

