### PR TITLE
Revamp Ambassador page 

### DIFF
--- a/src/components/ambassador-grid.tsx
+++ b/src/components/ambassador-grid.tsx
@@ -41,6 +41,30 @@ function buildRows(ambassador: Ambassador, emeritus: boolean): InfoCardRow[] {
             label: ambassador.organization,
           },
         ]),
+    ...(ambassador.organizes
+      ? [
+          {
+            type: "label" as const,
+            hideInConciseMode: true,
+            className: "bg-pri-lightest text-pri-darker dark:text-pri-darker",
+            label: (
+              <div className="typography-body-md flex flex-col leading-relaxed">
+                {ambassador.organizes.map(event => (
+                  <a
+                    key={event.url}
+                    href={event.url}
+                    className="gql-focus-visible underline decoration-pri-dark underline-offset-4 hover:text-pri-base"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {event.name} organizer
+                  </a>
+                ))}
+              </div>
+            ),
+          },
+        ]
+      : []),
     ...(ambassador.askMeAbout
       ? [
           {

--- a/src/components/ambassador-grid.tsx
+++ b/src/components/ambassador-grid.tsx
@@ -48,7 +48,7 @@ function buildRows(ambassador: Ambassador, emeritus: boolean): InfoCardRow[] {
             hideInConciseMode: true,
             className: "bg-pri-lightest text-pri-darker dark:text-pri-darker",
             label: (
-              <div className="typography-body-md flex flex-col leading-relaxed">
+              <div className="typography-body-sm flex flex-col whitespace-nowrap leading-relaxed">
                 {ambassador.organizes.map(event => (
                   <a
                     key={event.url}

--- a/src/components/ambassador-grid.tsx
+++ b/src/components/ambassador-grid.tsx
@@ -13,7 +13,7 @@ function buildRows(ambassador: Ambassador, emeritus: boolean): InfoCardRow[] {
               role="img"
               aria-label={ambassador.location.name}
               title={ambassador.location.name}
-              className="shrink-0 self-center text-xl"
+              className="shrink-0 self-start text-xl"
             >
               {ambassador.location.flag}
             </span>
@@ -41,6 +41,22 @@ function buildRows(ambassador: Ambassador, emeritus: boolean): InfoCardRow[] {
             label: ambassador.organization,
           },
         ]),
+    ...(ambassador.askMeAbout
+      ? [
+          {
+            type: "label" as const,
+            hideInConciseMode: true,
+            label: (
+              <div className="typography-body-md leading-relaxed">
+                <span className="mr-2 bg-sec-light px-1 text-neu-900 dark:bg-sec-darker">
+                  Ask me about
+                </span>
+                {ambassador.askMeAbout.join(", ")}
+              </div>
+            ),
+          },
+        ]
+      : []),
     {
       type: "label",
       hideInConciseMode: true,
@@ -75,7 +91,7 @@ export function AmbassadorGrid({
   emeritus?: boolean
 }) {
   return (
-    <div className="mx-auto mt-10 flex w-full max-w-6xl flex-wrap justify-center gap-8">
+    <div className="mx-auto mt-10 flex w-full max-w-6xl flex-wrap justify-center gap-6">
       {ambassadors.map((ambassador, index) => (
         <InfoCard
           key={`${ambassador.label}-${index}`}

--- a/src/components/ambassador-grid.tsx
+++ b/src/components/ambassador-grid.tsx
@@ -5,7 +5,21 @@ function buildRows(ambassador: Ambassador, emeritus: boolean): InfoCardRow[] {
   return [
     {
       type: "label",
-      label: ambassador.label,
+      label: (
+        <>
+          {ambassador.label}
+          {ambassador.location ? (
+            <span
+              role="img"
+              aria-label={ambassador.location.name}
+              title={ambassador.location.name}
+              className="shrink-0 self-center text-xl"
+            >
+              {ambassador.location.flag}
+            </span>
+          ) : null}
+        </>
+      ),
     },
     {
       type: "image",

--- a/src/components/ambassador-grid.tsx
+++ b/src/components/ambassador-grid.tsx
@@ -35,12 +35,7 @@ function buildRows(ambassador: Ambassador, emeritus: boolean): InfoCardRow[] {
             },
           ]
         : []
-      : [
-          {
-            type: "label" as const,
-            label: ambassador.organization,
-          },
-        ]),
+      : []),
     ...(ambassador.organizes
       ? [
           {

--- a/src/components/info-card/ambassador-data.tsx
+++ b/src/components/info-card/ambassador-data.tsx
@@ -25,6 +25,10 @@ export interface Ambassador {
   tags: AmbassadorTag[]
   emeritus?: boolean
   term?: string
+  location?: {
+    name: string
+    flag: string
+  }
 }
 
 export const ambassadors202509: Ambassador[] = [
@@ -33,6 +37,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "https://github.com/aexol.png",
     alt: "Artur Czemiel",
     organization: "GraphQL Editor",
+    location: {
+      name: "Poland",
+      flag: "🇵🇱",
+    },
     tags: [
       {
         label: "Bluesky",
@@ -58,6 +66,10 @@ export const ambassadors202509: Ambassador[] = [
     organization: "GraphQL Java",
     emeritus: true,
     term: "2025-2026",
+    location: {
+      name: "Australia",
+      flag: "🇦🇺",
+    },
     tags: [
       {
         label: "GitHub",
@@ -76,6 +88,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "https://github.com/dotansimha.png",
     alt: "Dotan Simha",
     organization: "The Guild",
+    location: {
+      name: "Israel",
+      flag: "🇮🇱",
+    },
     tags: [
       {
         label: "GitHub",
@@ -94,6 +110,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "https://github.com/eddeee888.png",
     alt: "Eddy Nguyen",
     organization: "Code Generator",
+    location: {
+      name: "Australia",
+      flag: "🇦🇺",
+    },
     tags: [
       {
         label: "GitHub",
@@ -122,6 +142,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "https://github.com/erikwrede.png",
     alt: "Erik Wrede",
     organization: "Strawberry GraphQL",
+    location: {
+      name: "Germany",
+      flag: "🇩🇪",
+    },
     tags: [
       {
         label: "GitHub",
@@ -140,6 +164,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "/img/ambassadors/itamar-kestenbaum.jpg",
     alt: "Itamar Kestenbaum",
     organization: "Meta Platforms",
+    location: {
+      name: "United States",
+      flag: "🇺🇸",
+    },
     tags: [
       {
         label: "Facebook",
@@ -163,6 +191,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "/img/ambassadors/jamie-barton.jpg",
     alt: "Jamie Barton",
     organization: "CartQL",
+    location: {
+      name: "United Kingdom",
+      flag: "🇬🇧",
+    },
     tags: [
       {
         label: "GitHub",
@@ -191,6 +223,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "/img/ambassadors/jeff-auriemma.jpg",
     alt: "Jeff Auriemma",
     organization: "Apollo",
+    location: {
+      name: "United States",
+      flag: "🇺🇸",
+    },
     tags: [
       {
         label: "Bluesky",
@@ -219,6 +255,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "https://github.com/jemgillam.png",
     alt: "Jem Gillam",
     organization: "Graphile",
+    location: {
+      name: "United Kingdom",
+      flag: "🇬🇧",
+    },
     tags: [
       {
         label: "Bluesky",
@@ -242,6 +282,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "https://github.com/captbaritone.png",
     alt: "Jordan Eldredge",
     organization: "Meta",
+    location: {
+      name: "United States",
+      flag: "🇺🇸",
+    },
     tags: [
       {
         label: "GitHub",
@@ -272,6 +316,10 @@ export const ambassadors202509: Ambassador[] = [
     organization: "GraphQL.js",
     emeritus: true,
     term: "2025-2026",
+    location: {
+      name: "Belgium",
+      flag: "🇧🇪",
+    },
     tags: [
       {
         label: "GitHub",
@@ -302,6 +350,10 @@ export const ambassadors202509: Ambassador[] = [
     organization: "Netflix",
     emeritus: true,
     term: "2025-2026",
+    location: {
+      name: "Canada",
+      flag: "🇨🇦",
+    },
     tags: [
       {
         label: "BlueSky",
@@ -332,6 +384,10 @@ export const ambassadors202509: Ambassador[] = [
     organization: "Independent",
     emeritus: true,
     term: "2025-2026",
+    location: {
+      name: "United States",
+      flag: "🇺🇸",
+    },
     tags: [
       {
         label: "BlueSky",
@@ -355,6 +411,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "https://github.com/patrick91.png",
     alt: "Patrick Arminio",
     organization: "Strawberry GraphQL",
+    location: {
+      name: "United Kingdom",
+      flag: "🇬🇧",
+    },
     tags: [
       {
         label: "BlueSky",
@@ -380,6 +440,10 @@ export const ambassadors202509: Ambassador[] = [
     organization: "urql & gql.tada",
     emeritus: true,
     term: "2025-2026",
+    location: {
+      name: "United Kingdom",
+      flag: "🇬🇧",
+    },
     tags: [
       {
         label: "BlueSky",
@@ -408,6 +472,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "/img/ambassadors/sarah-sanders.jpg",
     alt: "Sarah Sanders",
     organization: "PostHog",
+    location: {
+      name: "United States",
+      flag: "🇺🇸",
+    },
     tags: [
       {
         label: "LinkedIn",
@@ -421,6 +489,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "https://github.com/fotoetienne.png",
     alt: "Stephen Spalding",
     organization: "Netflix",
+    location: {
+      name: "United States",
+      flag: "🇺🇸",
+    },
     tags: [
       {
         label: "GitHub",
@@ -446,6 +518,10 @@ export const ambassadors202509: Ambassador[] = [
     organization: "Guild",
     emeritus: true,
     term: "2025-2026",
+    location: {
+      name: "United Kingdom",
+      flag: "🇬🇧",
+    },
     tags: [
       {
         label: "GitHub",
@@ -464,6 +540,10 @@ export const ambassadors202509: Ambassador[] = [
     imageUrl: "/img/ambassadors/warren-day.jpeg",
     alt: "Warren Day",
     organization: "Overstacked",
+    location: {
+      name: "United Kingdom",
+      flag: "🇬🇧",
+    },
     tags: [
       {
         label: "LinkedIn",
@@ -485,6 +565,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "https://github.com/vliegveld5.png",
     alt: "An Ngo",
     organization: "bol",
+    location: {
+      name: "Netherlands",
+      flag: "🇳🇱",
+    },
     tags: [
       {
         label: "GitHub",
@@ -503,6 +587,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "https://github.com/spyl94.png",
     alt: "Aurélien David",
     organization: "Pennylane",
+    location: {
+      name: "France",
+      flag: "🇫🇷",
+    },
     tags: [
       {
         label: "GitHub",
@@ -526,6 +614,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "/img/ambassadors/chanda-raj-kumar.jpg",
     alt: "Chanda Raj Kumar",
     organization: "KL University Hyderabad",
+    location: {
+      name: "India",
+      flag: "🇮🇳",
+    },
     tags: [
       {
         label: "LinkedIn",
@@ -539,6 +631,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "https://github.com/dariuszkuc.png",
     alt: "Derek Kuc",
     organization: "Apollo",
+    location: {
+      name: "United States",
+      flag: "🇺🇸",
+    },
     tags: [
       {
         label: "Bluesky",
@@ -567,6 +663,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "https://github.com/gilgardosh.png",
     alt: "Gil Gardosh",
     organization: "The Guild",
+    location: {
+      name: "Israel",
+      flag: "🇮🇱",
+    },
     tags: [
       {
         label: "GitHub",
@@ -590,6 +690,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "/img/ambassadors/giuseppe-abrignani.jpg",
     alt: "Giuseppe Abrignani",
     organization: "Oranj Tech",
+    location: {
+      name: "Denmark",
+      flag: "🇩🇰",
+    },
     tags: [
       {
         label: "LinkedIn",
@@ -603,6 +707,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "/img/ambassadors/jayant-acharya.jpg",
     alt: "Jayant Acharya",
     organization: "Techsophy",
+    location: {
+      name: "India",
+      flag: "🇮🇳",
+    },
     tags: [
       {
         label: "GitHub",
@@ -621,6 +729,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: " https://github.com/n1ru4l.png",
     alt: "Laurin Quast",
     organization: "The Guild",
+    location: {
+      name: "Germany",
+      flag: "🇩🇪",
+    },
     tags: [
       {
         label: "GitHub",
@@ -644,6 +756,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "https://github.com/phryneas.png",
     alt: "Lenz Weber-Tronic",
     organization: "Apollo",
+    location: {
+      name: "Germany",
+      flag: "🇩🇪",
+    },
     tags: [
       {
         label: "Bluesky",
@@ -672,6 +788,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "https://github.com/riginoommen.png",
     alt: "Rigin Oommen",
     organization: "Red Hat",
+    location: {
+      name: "India",
+      flag: "🇮🇳",
+    },
     tags: [
       {
         label: "GitHub",
@@ -690,6 +810,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "/img/ambassadors/sabrina-wasserman.jpg",
     alt: "Sabrina Wasserman",
     organization: "Facebook",
+    location: {
+      name: "United States",
+      flag: "🇺🇸",
+    },
     tags: [
       {
         label: "GitHub",
@@ -708,6 +832,10 @@ export const ambassadors202512: Ambassador[] = [
     imageUrl: "https://github.com/EmrysMyrddin.png",
     alt: "Valentin Cocaud",
     organization: "Independent",
+    location: {
+      name: "France",
+      flag: "🇫🇷",
+    },
     tags: [
       {
         label: "GitHub",
@@ -729,6 +857,10 @@ export const ambassadors202603: Ambassador[] = [
     imageUrl: "/img/ambassadors/akshat-sharma.jpg",
     alt: "Akshat Sharma",
     organization: "Deskree",
+    location: {
+      name: "India",
+      flag: "🇮🇳",
+    },
     tags: [
       {
         label: "LinkedIn",
@@ -747,6 +879,10 @@ export const ambassadors202603: Ambassador[] = [
     imageUrl: "/img/ambassadors/ayush-more.jpg",
     alt: "Ayush More",
     organization: "Independent",
+    location: {
+      name: "India",
+      flag: "🇮🇳",
+    },
     tags: [
       {
         label: "GitHub",
@@ -770,6 +906,10 @@ export const ambassadors202603: Ambassador[] = [
     imageUrl: "/img/ambassadors/emily-goodwin.jpg",
     alt: "Emily Goodwin",
     organization: "Independent",
+    location: {
+      name: "Canada",
+      flag: "🇨🇦",
+    },
     tags: [
       {
         label: "GitHub",
@@ -788,6 +928,10 @@ export const ambassadors202603: Ambassador[] = [
     imageUrl: "https://github.com/IvanGoncharov.png",
     alt: "Ivan Goncharov",
     organization: "APIs.guru",
+    location: {
+      name: "Ukraine",
+      flag: "🇺🇦",
+    },
     tags: [
       {
         label: "GitHub",
@@ -809,6 +953,10 @@ export const ambassadors202606: Ambassador[] = [
     imageUrl: "/img/ambassadors/christian-ernst.jpg",
     alt: "Christian Ernst",
     organization: "Booking.com",
+    location: {
+      name: "Netherlands",
+      flag: "🇳🇱",
+    },
     tags: [
       {
         label: "LinkedIn",
@@ -822,6 +970,10 @@ export const ambassadors202606: Ambassador[] = [
     imageUrl: "/img/ambassadors/zeljko-kozina.jpg",
     alt: "Željko Kozina",
     organization: "Chronomill",
+    location: {
+      name: "Ireland",
+      flag: "🇮🇪",
+    },
     tags: [
       {
         label: "LinkedIn",

--- a/src/components/info-card/ambassador-data.tsx
+++ b/src/components/info-card/ambassador-data.tsx
@@ -29,6 +29,7 @@ export interface Ambassador {
     name: string
     flag: string
   }
+  askMeAbout?: string[]
 }
 
 export const ambassadors202509: Ambassador[] = [
@@ -259,6 +260,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United Kingdom",
       flag: "🇬🇧",
     },
+    askMeAbout: ["GraphQL governance", "Open source sustainability"],
     tags: [
       {
         label: "Bluesky",

--- a/src/components/info-card/ambassador-data.tsx
+++ b/src/components/info-card/ambassador-data.tsx
@@ -1097,6 +1097,15 @@ export const ambassadors202609: Ambassador[] = [
     imageUrl: "https://github.com/eeshaanSA.png",
     alt: "Eeshaan Sawant",
     organization: "Independent",
+    location: {
+      name: "India",
+      flag: "🇮🇳",
+    },
+    askMeAbout: [
+      "API governance",
+      "continuous delivery",
+      "developer communities",
+    ],
     tags: [
       {
         label: "GitHub",
@@ -1125,6 +1134,15 @@ export const ambassadors202609: Ambassador[] = [
     imageUrl: "https://github.com/jeanlucaslima.png",
     alt: "Jean Lucas Lima",
     organization: "Independent",
+    location: {
+      name: "Brazil",
+      flag: "🇧🇷",
+    },
+    askMeAbout: [
+      "developer communities",
+      "distributed systems",
+      "GraphQL architecture",
+    ],
     tags: [
       {
         label: "GitHub",

--- a/src/components/info-card/ambassador-data.tsx
+++ b/src/components/info-card/ambassador-data.tsx
@@ -245,6 +245,12 @@ export const ambassadors202509: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    organizes: [
+      {
+        name: "GraphQL Virtual",
+        url: "https://guild.host/graphql-virtual",
+      },
+    ],
     askMeAbout: ["GraphQL clients", "GraphQL governance", "schema design"],
     tags: [
       {
@@ -508,6 +514,12 @@ export const ambassadors202509: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    organizes: [
+      {
+        name: "Philly GraphQL",
+        url: "https://luma.com/phillygraphql",
+      },
+    ],
     askMeAbout: ["developer experience", "GraphQL education"],
     tags: [
       {
@@ -605,6 +617,12 @@ export const ambassadors202512: Ambassador[] = [
       name: "Netherlands",
       flag: "🇳🇱",
     },
+    organizes: [
+      {
+        name: "GraphQL Amsterdam",
+        url: "https://www.meetup.com/amsterdam-graphql-meetup",
+      },
+    ],
     askMeAbout: ["enterprise GraphQL", "federation", "GraphQL at scale"],
     tags: [
       {
@@ -656,6 +674,12 @@ export const ambassadors202512: Ambassador[] = [
       name: "India",
       flag: "🇮🇳",
     },
+    organizes: [
+      {
+        name: "GraphQL Hyderabad",
+        url: "https://guild.host/graphql-hyderabad/",
+      },
+    ],
     askMeAbout: ["GraphQL & AI", "GraphQL education"],
     tags: [
       {
@@ -753,6 +777,12 @@ export const ambassadors202512: Ambassador[] = [
       name: "India",
       flag: "🇮🇳",
     },
+    organizes: [
+      {
+        name: "GraphQL Hyderabad",
+        url: "https://guild.host/graphql-hyderabad",
+      },
+    ],
     askMeAbout: ["GraphQL education"],
     tags: [
       {
@@ -960,6 +990,12 @@ export const ambassadors202603: Ambassador[] = [
       name: "Canada",
       flag: "🇨🇦",
     },
+    organizes: [
+      {
+        name: "GraphQL Toronto",
+        url: "https://guild.host/graphql-toronto",
+      },
+    ],
     askMeAbout: ["caching", "federation", "GraphQL tooling"],
     tags: [
       {
@@ -1009,6 +1045,12 @@ export const ambassadors202606: Ambassador[] = [
       name: "Netherlands",
       flag: "🇳🇱",
     },
+    organizes: [
+      {
+        name: "GraphQL Amsterdam",
+        url: "https://www.meetup.com/amsterdam-graphql-meetup",
+      },
+    ],
     askMeAbout: ["enterprise GraphQL", "federation", "schema evolution"],
     tags: [
       {

--- a/src/components/info-card/ambassador-data.tsx
+++ b/src/components/info-card/ambassador-data.tsx
@@ -157,6 +157,12 @@ export const ambassadors202509: Ambassador[] = [
       name: "Germany",
       flag: "🇩🇪",
     },
+    organizes: [
+      {
+        name: "GraphQL Amsterdam",
+        url: "https://www.meetup.com/amsterdam-graphql-meetup",
+      },
+    ],
     askMeAbout: ["Python GraphQL", "Strawberry GraphQL", "GraphQL & AI"],
     tags: [
       {
@@ -962,7 +968,7 @@ export const ambassadors202603: Ambassador[] = [
       name: "India",
       flag: "🇮🇳",
     },
-    askMeAbout: ["student outreach"],
+    askMeAbout: ["the CNCF community, getting started with GraphQL"],
     tags: [
       {
         label: "GitHub",

--- a/src/components/info-card/ambassador-data.tsx
+++ b/src/components/info-card/ambassador-data.tsx
@@ -17,6 +17,11 @@ export interface AmbassadorTag {
   icon?: ReactNode
 }
 
+export interface AmbassadorEvent {
+  name: string
+  url: string
+}
+
 export interface Ambassador {
   label: string
   imageUrl: string
@@ -29,6 +34,7 @@ export interface Ambassador {
     name: string
     flag: string
   }
+  organizes?: AmbassadorEvent[]
   askMeAbout?: string[]
 }
 
@@ -260,6 +266,12 @@ export const ambassadors202509: Ambassador[] = [
       name: "United Kingdom",
       flag: "🇬🇧",
     },
+    organizes: [
+      {
+        name: "London GraphQL",
+        url: "https://guild.host/london-graphql",
+      },
+    ],
     askMeAbout: ["GraphQL governance", "Open source sustainability"],
     tags: [
       {

--- a/src/components/info-card/ambassador-data.tsx
+++ b/src/components/info-card/ambassador-data.tsx
@@ -26,7 +26,6 @@ export interface Ambassador {
   label: string
   imageUrl: string
   alt: string
-  organization: string
   tags: AmbassadorTag[]
   emeritus?: boolean
   term?: string
@@ -43,7 +42,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Artur Czemiel",
     imageUrl: "https://github.com/aexol.png",
     alt: "Artur Czemiel",
-    organization: "GraphQL Editor",
     location: {
       name: "Poland",
       flag: "🇵🇱",
@@ -71,7 +69,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Donna Zhou",
     imageUrl: "/img/ambassadors/donna-zhou.jpg",
     alt: "Donna Zhou",
-    organization: "GraphQL Java",
     emeritus: true,
     term: "2025-2026",
     location: {
@@ -96,7 +93,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Dotan Simha",
     imageUrl: "https://github.com/dotansimha.png",
     alt: "Dotan Simha",
-    organization: "The Guild",
     location: {
       name: "Israel",
       flag: "🇮🇱",
@@ -119,7 +115,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Eddy Nguyen",
     imageUrl: "https://github.com/eddeee888.png",
     alt: "Eddy Nguyen",
-    organization: "Code Generator",
     location: {
       name: "Australia",
       flag: "🇦🇺",
@@ -152,7 +147,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Erik Wrede",
     imageUrl: "https://github.com/erikwrede.png",
     alt: "Erik Wrede",
-    organization: "Strawberry GraphQL",
     location: {
       name: "Germany",
       flag: "🇩🇪",
@@ -181,7 +175,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Itamar Kestenbaum",
     imageUrl: "/img/ambassadors/itamar-kestenbaum.jpg",
     alt: "Itamar Kestenbaum",
-    organization: "Meta Platforms",
     location: {
       name: "United States",
       flag: "🇺🇸",
@@ -209,7 +202,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Jamie Barton",
     imageUrl: "/img/ambassadors/jamie-barton.jpg",
     alt: "Jamie Barton",
-    organization: "CartQL",
     location: {
       name: "United Kingdom",
       flag: "🇬🇧",
@@ -246,7 +238,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Jeff Auriemma",
     imageUrl: "/img/ambassadors/jeff-auriemma.jpg",
     alt: "Jeff Auriemma",
-    organization: "Apollo",
     location: {
       name: "United States",
       flag: "🇺🇸",
@@ -285,7 +276,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Jem Gillam",
     imageUrl: "https://github.com/jemgillam.png",
     alt: "Jem Gillam",
-    organization: "Graphile",
     location: {
       name: "United Kingdom",
       flag: "🇬🇧",
@@ -319,7 +309,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Jordan Eldredge",
     imageUrl: "https://github.com/captbaritone.png",
     alt: "Jordan Eldredge",
-    organization: "Meta",
     location: {
       name: "United States",
       flag: "🇺🇸",
@@ -352,7 +341,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Jovi De Croock",
     imageUrl: "https://github.com/jovidecroock.png",
     alt: "Jovi De Croock",
-    organization: "GraphQL.js",
     emeritus: true,
     term: "2025-2026",
     location: {
@@ -387,7 +375,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Marc-Andre Giroux",
     imageUrl: "https://github.com/xuorig.png",
     alt: "Marc-Andre Giroux",
-    organization: "Netflix",
     emeritus: true,
     term: "2025-2026",
     location: {
@@ -422,7 +409,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Michael Watson",
     imageUrl: "https://github.com/michael-watson.png",
     alt: "Michael Watson",
-    organization: "Independent",
     emeritus: true,
     term: "2025-2026",
     location: {
@@ -452,7 +438,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Patrick Arminio",
     imageUrl: "https://github.com/patrick91.png",
     alt: "Patrick Arminio",
-    organization: "Strawberry GraphQL",
     location: {
       name: "United Kingdom",
       flag: "🇬🇧",
@@ -480,7 +465,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Phil Pluckthun",
     imageUrl: "https://github.com/kitten.png",
     alt: "Phil Pluckthun",
-    organization: "urql & gql.tada",
     emeritus: true,
     term: "2025-2026",
     location: {
@@ -515,7 +499,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Sarah Sanders",
     imageUrl: "/img/ambassadors/sarah-sanders.jpg",
     alt: "Sarah Sanders",
-    organization: "PostHog",
     location: {
       name: "United States",
       flag: "🇺🇸",
@@ -539,7 +522,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Stephen Spalding",
     imageUrl: "https://github.com/fotoetienne.png",
     alt: "Stephen Spalding",
-    organization: "Netflix",
     location: {
       name: "United States",
       flag: "🇺🇸",
@@ -567,7 +549,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Taz Singh",
     imageUrl: "https://github.com/tazsingh.png",
     alt: "Taz Singh",
-    organization: "Guild",
     emeritus: true,
     term: "2025-2026",
     location: {
@@ -592,7 +573,6 @@ export const ambassadors202509: Ambassador[] = [
     label: "Warren Day",
     imageUrl: "/img/ambassadors/warren-day.jpeg",
     alt: "Warren Day",
-    organization: "Overstacked",
     location: {
       name: "United Kingdom",
       flag: "🇬🇧",
@@ -618,7 +598,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "An Ngo",
     imageUrl: "https://github.com/vliegveld5.png",
     alt: "An Ngo",
-    organization: "bol",
     location: {
       name: "Netherlands",
       flag: "🇳🇱",
@@ -647,7 +626,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Aurélien David",
     imageUrl: "https://github.com/spyl94.png",
     alt: "Aurélien David",
-    organization: "Pennylane",
     location: {
       name: "France",
       flag: "🇫🇷",
@@ -675,7 +653,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Chanda Raj Kumar",
     imageUrl: "/img/ambassadors/chanda-raj-kumar.jpg",
     alt: "Chanda Raj Kumar",
-    organization: "KL University Hyderabad",
     location: {
       name: "India",
       flag: "🇮🇳",
@@ -699,7 +676,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Derek Kuc",
     imageUrl: "https://github.com/dariuszkuc.png",
     alt: "Derek Kuc",
-    organization: "Apollo",
     location: {
       name: "United States",
       flag: "🇺🇸",
@@ -732,7 +708,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Gil Gardosh",
     imageUrl: "https://github.com/gilgardosh.png",
     alt: "Gil Gardosh",
-    organization: "The Guild",
     location: {
       name: "Israel",
       flag: "🇮🇱",
@@ -760,7 +735,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Giuseppe Abrignani",
     imageUrl: "/img/ambassadors/giuseppe-abrignani.jpg",
     alt: "Giuseppe Abrignani",
-    organization: "Oranj Tech",
     location: {
       name: "Denmark",
       flag: "🇩🇰",
@@ -778,7 +752,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Jayant Acharya",
     imageUrl: "/img/ambassadors/jayant-acharya.jpg",
     alt: "Jayant Acharya",
-    organization: "Techsophy",
     location: {
       name: "India",
       flag: "🇮🇳",
@@ -807,7 +780,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Laurin Quast",
     imageUrl: " https://github.com/n1ru4l.png",
     alt: "Laurin Quast",
-    organization: "The Guild",
     location: {
       name: "Germany",
       flag: "🇩🇪",
@@ -835,7 +807,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Lenz Weber-Tronic",
     imageUrl: "https://github.com/phryneas.png",
     alt: "Lenz Weber-Tronic",
-    organization: "Apollo",
     location: {
       name: "Germany",
       flag: "🇩🇪",
@@ -868,7 +839,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Rigin Oommen",
     imageUrl: "https://github.com/riginoommen.png",
     alt: "Rigin Oommen",
-    organization: "Red Hat",
     location: {
       name: "India",
       flag: "🇮🇳",
@@ -891,7 +861,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Sabrina Wasserman",
     imageUrl: "/img/ambassadors/sabrina-wasserman.jpg",
     alt: "Sabrina Wasserman",
-    organization: "Facebook",
     location: {
       name: "United States",
       flag: "🇺🇸",
@@ -914,7 +883,6 @@ export const ambassadors202512: Ambassador[] = [
     label: "Valentin Cocaud",
     imageUrl: "https://github.com/EmrysMyrddin.png",
     alt: "Valentin Cocaud",
-    organization: "Independent",
     location: {
       name: "France",
       flag: "🇫🇷",
@@ -940,7 +908,6 @@ export const ambassadors202603: Ambassador[] = [
     label: "Akshat Sharma",
     imageUrl: "/img/ambassadors/akshat-sharma.jpg",
     alt: "Akshat Sharma",
-    organization: "Deskree",
     location: {
       name: "India",
       flag: "🇮🇳",
@@ -963,7 +930,6 @@ export const ambassadors202603: Ambassador[] = [
     label: "Ayush More",
     imageUrl: "/img/ambassadors/ayush-more.jpg",
     alt: "Ayush More",
-    organization: "Independent",
     location: {
       name: "India",
       flag: "🇮🇳",
@@ -991,7 +957,6 @@ export const ambassadors202603: Ambassador[] = [
     label: "Emily Goodwin",
     imageUrl: "/img/ambassadors/emily-goodwin.jpg",
     alt: "Emily Goodwin",
-    organization: "Independent",
     location: {
       name: "Canada",
       flag: "🇨🇦",
@@ -1020,7 +985,6 @@ export const ambassadors202603: Ambassador[] = [
     label: "Ivan Goncharov",
     imageUrl: "https://github.com/IvanGoncharov.png",
     alt: "Ivan Goncharov",
-    organization: "APIs.guru",
     location: {
       name: "Ukraine",
       flag: "🇺🇦",
@@ -1046,7 +1010,6 @@ export const ambassadors202606: Ambassador[] = [
     label: "Christian Ernst",
     imageUrl: "/img/ambassadors/christian-ernst.jpg",
     alt: "Christian Ernst",
-    organization: "Booking.com",
     location: {
       name: "Netherlands",
       flag: "🇳🇱",
@@ -1070,7 +1033,6 @@ export const ambassadors202606: Ambassador[] = [
     label: "Željko Kozina",
     imageUrl: "/img/ambassadors/zeljko-kozina.jpg",
     alt: "Željko Kozina",
-    organization: "Chronomill",
     location: {
       name: "Ireland",
       flag: "🇮🇪",
@@ -1096,7 +1058,6 @@ export const ambassadors202609: Ambassador[] = [
     label: "Eeshaan Sawant",
     imageUrl: "https://github.com/eeshaanSA.png",
     alt: "Eeshaan Sawant",
-    organization: "Independent",
     location: {
       name: "India",
       flag: "🇮🇳",
@@ -1133,7 +1094,6 @@ export const ambassadors202609: Ambassador[] = [
     label: "Jean Lucas Lima",
     imageUrl: "https://github.com/jeanlucaslima.png",
     alt: "Jean Lucas Lima",
-    organization: "Independent",
     location: {
       name: "Brazil",
       flag: "🇧🇷",

--- a/src/components/info-card/ambassador-data.tsx
+++ b/src/components/info-card/ambassador-data.tsx
@@ -48,6 +48,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "Poland",
       flag: "🇵🇱",
     },
+    askMeAbout: ["GraphQL Editor", "GraphQL Zeus", "schema design"],
     tags: [
       {
         label: "Bluesky",
@@ -77,6 +78,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "Australia",
       flag: "🇦🇺",
     },
+    askMeAbout: ["GraphQL Java", "open source"],
     tags: [
       {
         label: "GitHub",
@@ -99,6 +101,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "Israel",
       flag: "🇮🇱",
     },
+    askMeAbout: ["GraphQL Yoga", "federation"],
     tags: [
       {
         label: "GitHub",
@@ -121,6 +124,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "Australia",
       flag: "🇦🇺",
     },
+    askMeAbout: ["GraphQL Code Generator", "type safety"],
     tags: [
       {
         label: "GitHub",
@@ -153,6 +157,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "Germany",
       flag: "🇩🇪",
     },
+    askMeAbout: ["Python GraphQL", "Strawberry GraphQL", "GraphQL & AI"],
     tags: [
       {
         label: "GitHub",
@@ -175,6 +180,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    askMeAbout: ["error handling", "GraphQL at scale", "nullability"],
     tags: [
       {
         label: "Facebook",
@@ -202,6 +208,11 @@ export const ambassadors202509: Ambassador[] = [
       name: "United Kingdom",
       flag: "🇬🇧",
     },
+    askMeAbout: [
+      "developer tooling",
+      "GraphQL at the edge",
+      "GraphQL education",
+    ],
     tags: [
       {
         label: "GitHub",
@@ -234,6 +245,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    askMeAbout: ["GraphQL clients", "GraphQL governance", "schema design"],
     tags: [
       {
         label: "Bluesky",
@@ -272,7 +284,7 @@ export const ambassadors202509: Ambassador[] = [
         url: "https://guild.host/london-graphql",
       },
     ],
-    askMeAbout: ["GraphQL governance", "Open source sustainability"],
+    askMeAbout: ["GraphQL governance", "open source"],
     tags: [
       {
         label: "Bluesky",
@@ -300,6 +312,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    askMeAbout: ["Grats", "Relay", "nullability"],
     tags: [
       {
         label: "GitHub",
@@ -334,6 +347,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "Belgium",
       flag: "🇧🇪",
     },
+    askMeAbout: ["gql.tada", "urql"],
     tags: [
       {
         label: "GitHub",
@@ -368,6 +382,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "Canada",
       flag: "🇨🇦",
     },
+    askMeAbout: ["API architecture", "GraphQL at scale", "production GraphQL"],
     tags: [
       {
         label: "BlueSky",
@@ -402,6 +417,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    askMeAbout: ["enterprise GraphQL", "GraphQL & AI", "schema design"],
     tags: [
       {
         label: "BlueSky",
@@ -429,6 +445,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United Kingdom",
       flag: "🇬🇧",
     },
+    askMeAbout: ["Strawberry GraphQL", "code-first GraphQL, type safety"],
     tags: [
       {
         label: "BlueSky",
@@ -458,6 +475,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United Kingdom",
       flag: "🇬🇧",
     },
+    askMeAbout: ["gql.tada", "urql"],
     tags: [
       {
         label: "BlueSky",
@@ -490,6 +508,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    askMeAbout: ["developer experience", "GraphQL education"],
     tags: [
       {
         label: "LinkedIn",
@@ -507,6 +526,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    askMeAbout: ["GraphQL & AI", "GraphQL at scale", "nullability"],
     tags: [
       {
         label: "GitHub",
@@ -536,6 +556,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United Kingdom",
       flag: "🇬🇧",
     },
+    askMeAbout: ["community building", "production GraphQL"],
     tags: [
       {
         label: "GitHub",
@@ -558,6 +579,7 @@ export const ambassadors202509: Ambassador[] = [
       name: "United Kingdom",
       flag: "🇬🇧",
     },
+    askMeAbout: ["GraphQL Network Inspector", "debugging", "developer tooling"],
     tags: [
       {
         label: "LinkedIn",
@@ -583,6 +605,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "Netherlands",
       flag: "🇳🇱",
     },
+    askMeAbout: ["enterprise GraphQL", "federation", "GraphQL at scale"],
     tags: [
       {
         label: "GitHub",
@@ -605,6 +628,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "France",
       flag: "🇫🇷",
     },
+    askMeAbout: ["API migration", "GraphQL education", "public APIs"],
     tags: [
       {
         label: "GitHub",
@@ -632,6 +656,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "India",
       flag: "🇮🇳",
     },
+    askMeAbout: ["GraphQL & AI", "GraphQL education"],
     tags: [
       {
         label: "LinkedIn",
@@ -649,6 +674,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    askMeAbout: ["Apollo Federation", "GraphQL testing"],
     tags: [
       {
         label: "Bluesky",
@@ -681,6 +707,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "Israel",
       flag: "🇮🇱",
     },
+    askMeAbout: ["GraphQL Mesh", "API integration", "federation"],
     tags: [
       {
         label: "GitHub",
@@ -708,6 +735,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "Denmark",
       flag: "🇩🇰",
     },
+    askMeAbout: ["data modelling", "GraphQL at scale", "schema tooling"],
     tags: [
       {
         label: "LinkedIn",
@@ -725,6 +753,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "India",
       flag: "🇮🇳",
     },
+    askMeAbout: ["GraphQL education"],
     tags: [
       {
         label: "GitHub",
@@ -747,6 +776,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "Germany",
       flag: "🇩🇪",
     },
+    askMeAbout: ["GraphQL Hive", "schema evolution"],
     tags: [
       {
         label: "GitHub",
@@ -774,6 +804,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "Germany",
       flag: "🇩🇪",
     },
+    askMeAbout: ["Apollo Client", "GraphQL clients"],
     tags: [
       {
         label: "Bluesky",
@@ -806,6 +837,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "India",
       flag: "🇮🇳",
     },
+    askMeAbout: ["API design", "developer experience", "schema evolution"],
     tags: [
       {
         label: "GitHub",
@@ -828,6 +860,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "United States",
       flag: "🇺🇸",
     },
+    askMeAbout: ["data consistency", "GraphQL clients", "pagination"],
     tags: [
       {
         label: "GitHub",
@@ -850,6 +883,7 @@ export const ambassadors202512: Ambassador[] = [
       name: "France",
       flag: "🇫🇷",
     },
+    askMeAbout: ["GraphQL Gateway", "GraphQL Mesh", "GraphQL Yoga"],
     tags: [
       {
         label: "GitHub",
@@ -875,6 +909,7 @@ export const ambassadors202603: Ambassador[] = [
       name: "India",
       flag: "🇮🇳",
     },
+    askMeAbout: ["developer advocacy", "GraphQL & AI"],
     tags: [
       {
         label: "LinkedIn",
@@ -897,6 +932,7 @@ export const ambassadors202603: Ambassador[] = [
       name: "India",
       flag: "🇮🇳",
     },
+    askMeAbout: ["student outreach"],
     tags: [
       {
         label: "GitHub",
@@ -924,6 +960,7 @@ export const ambassadors202603: Ambassador[] = [
       name: "Canada",
       flag: "🇨🇦",
     },
+    askMeAbout: ["caching", "federation", "GraphQL tooling"],
     tags: [
       {
         label: "GitHub",
@@ -946,6 +983,7 @@ export const ambassadors202603: Ambassador[] = [
       name: "Ukraine",
       flag: "🇺🇦",
     },
+    askMeAbout: ["GraphQL Voyager", "GraphQL specification", "GraphQL tooling"],
     tags: [
       {
         label: "GitHub",
@@ -971,6 +1009,7 @@ export const ambassadors202606: Ambassador[] = [
       name: "Netherlands",
       flag: "🇳🇱",
     },
+    askMeAbout: ["enterprise GraphQL", "federation", "schema evolution"],
     tags: [
       {
         label: "LinkedIn",
@@ -988,6 +1027,7 @@ export const ambassadors202606: Ambassador[] = [
       name: "Ireland",
       flag: "🇮🇪",
     },
+    askMeAbout: ["Spring for GraphQL", "API design", "GraphQL & AI"],
     tags: [
       {
         label: "LinkedIn",

--- a/src/components/info-card/index.tsx
+++ b/src/components/info-card/index.tsx
@@ -5,6 +5,7 @@ export interface InfoCardLabelRow {
   type: "label"
   label: ReactNode
   hideInConciseMode?: boolean
+  className?: string
 }
 
 export interface InfoCardTitleRow {
@@ -32,7 +33,12 @@ export function InfoCardRow({ row }: { row: InfoCardRow }) {
   switch (row.type) {
     case "label": {
       return (
-        <div className="flex h-auto items-start justify-between gap-2 border-b border-neu-200 p-4 text-neu-700 dark:border-neu-100 dark:text-neu-600">
+        <div
+          className={clsx(
+            "flex h-auto items-start justify-between gap-2 border-b border-neu-200 p-4 text-neu-700 dark:border-neu-100 dark:text-neu-600",
+            row.className,
+          )}
+        >
           {row.label}
         </div>
       )

--- a/src/components/info-card/index.tsx
+++ b/src/components/info-card/index.tsx
@@ -62,7 +62,7 @@ export function InfoCard({ rows, concise, className }: InfoCardProps) {
   return (
     <div
       className={clsx(
-        "gql-focus-visible group flex w-[240px] flex-col overflow-hidden border border-neu-200 bg-neu-0 text-left text-current no-underline ring-neu-400 dark:border-neu-100 dark:ring-neu-100",
+        "gql-focus-visible group flex w-64 flex-col overflow-hidden border border-neu-200 bg-neu-0 text-left text-current no-underline ring-neu-400 dark:border-neu-100 dark:ring-neu-100",
         className,
       )}
     >


### PR DESCRIPTION
I have had feedback from TSC, community members, and end users that our Ambassador page isn't as useful as it potentially could be. 

I have redesigned the cards shown on https://graphql.org/community/ambassadors/ to show the Ambassador's location, their strengths, and if they are a Locals organiser it also links to their events page. 

I suggest that for the list of "Ask me about" topics we keep it to a kind of normalized list, and also the name of the project the person maintains (if applicable)


**Ambassadors Please check your information**. I have taken your locations from your LinkedIn / GitHub profiles and I chose your areas of interest from your Ambassador application or recent talks you've given. You can make a comment or a code suggestion to update your information, please only choose up to three things to put as your area of interest. 

You can see the new page here: https://graphql-github-io-git-fork-jemgi-979085-the-graph-ql-foundation.vercel.app/community/ambassadors/

**Website maintainers** Please don't merge this until it has been checked by the Ambassadors! 

**We're looking to push this live in the week commencing 7th September**


Old version:
<img width="809" height="809" alt="Screenshot 2026-08-29 at 11 35 44" src="https://github.com/user-attachments/assets/0ff21bd7-cd13-4f9b-9a66-d85579ede3aa" />



New version:
Light: 
<img width="929" height="1090" alt="Screenshot 2026-08-29 at 11 33 06" src="https://github.com/user-attachments/assets/abf6bb59-e04d-491b-b501-331a90df101d" />

Dark: 
<img width="920" height="1094" alt="Screenshot 2026-08-29 at 11 33 50" src="https://github.com/user-attachments/assets/af25df29-70e9-42bc-bf20-f56d3dec53b4" />
